### PR TITLE
Remove unique_name from service specs

### DIFF
--- a/loadbalanced-fargate-svc/service/infrastructure/cloudformation.yaml
+++ b/loadbalanced-fargate-svc/service/infrastructure/cloudformation.yaml
@@ -22,14 +22,14 @@ Resources:
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: '{{service_instance.unique_name}}'
+      LogGroupName: '{{service_name}}/{{service_instance_name}}'
 
   # The task definition. This is a simple metadata description of what
   # container to run, and what resource requirements it has.
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:
-      Family: '{{service_instance.unique_name}}'
+      Family: '{{service_name}}_{{service_instance_name}}'
       Cpu: !FindInMap [TaskSize, {{service_instance.task_size}}, cpu]
       Memory: !FindInMap [TaskSize, {{service_instance.task_size}}, memory]
       NetworkMode: awsvpc
@@ -38,7 +38,7 @@ Resources:
       ExecutionRoleArn: '{{environment.ECSTaskExecutionRole}}'
       TaskRoleArn: !Ref "AWS::NoValue"
       ContainerDefinitions:
-        - Name: '{{service_instance.unique_name}}'
+        - Name: '{{service_instance_name}}'
           Cpu: !FindInMap [TaskSize, {{service_instance.task_size}}, cpu]
           Memory: !FindInMap [TaskSize, {{service_instance.task_size}}, memory]
           Image: '{{service_instance.image}}'
@@ -47,9 +47,9 @@ Resources:
           LogConfiguration:
             LogDriver: 'awslogs'
             Options:
-              awslogs-group: '{{service_instance.unique_name}}'
+              awslogs-group: '{{service_name}}/{{service_instance_name}}'
               awslogs-region: !Ref 'AWS::Region'
-              awslogs-stream-prefix: '{{service_instance.unique_name}}'
+              awslogs-stream-prefix: '{{service_name}}/{{service_instance_name}}'
 
   # The service_instance. The service is a resource which allows you to run multiple
   # copies of a type of task, and gather up their logs and metrics, as well
@@ -58,7 +58,7 @@ Resources:
     Type: AWS::ECS::Service
     DependsOn: LoadBalancerRule
     Properties:
-      ServiceName: '{{service_instance.unique_name}}'
+      ServiceName: '{{service_name}}_{{service_instance_name}}'
       Cluster: '{{environment.ClusterName}}'
       LaunchType: FARGATE
       DeploymentConfiguration:
@@ -75,7 +75,7 @@ Resources:
             - '{{environment.PublicSubnetTwo}}'
       TaskDefinition: !Ref 'TaskDefinition'
       LoadBalancers:
-        - ContainerName: '{{service_instance.unique_name}}'
+        - ContainerName: '{{service_instance_name}}'
           ContainerPort: '{{service_instance.port}}'
           TargetGroupArn: !Ref 'TargetGroup'
 
@@ -93,7 +93,10 @@ Resources:
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
       TargetType: ip
-      Name: '{{service_instance.unique_name}}'
+      # Note that the Name property has a 32 character limit, which could be
+      # reached by using either {{service_name}}, {{service_instance_name}}
+      # or a combination of both as we're doing here
+      Name: '{{service_name}}--{{service_instance_name}}'
       Port: '{{service_instance.port}}'
       Protocol: HTTP
       UnhealthyThresholdCount: 2
@@ -125,7 +128,7 @@ Resources:
           - '/'
           - - service
             - '{{environment.ClusterName}}'
-            - '{{service_instance.unique_name}}'
+            - '{{service_name}}_{{service_instance_name}}'
       MinCapacity: 1
       MaxCapacity: 10
       RoleARN: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService
@@ -139,7 +142,7 @@ Resources:
         Fn::Join:
           - '/'
           - - scale
-            - '{{service_instance.unique_name}}'
+            - '{{service_name}}_{{service_instance_name}}'
             - down
       PolicyType: StepScaling
       ResourceId:
@@ -147,7 +150,7 @@ Resources:
           - '/'
           - - service
             - '{{environment.ClusterName}}'
-            - '{{service_instance.unique_name}}'
+            - '{{service_name}}_{{service_instance_name}}'
       ScalableDimension: 'ecs:service:DesiredCount'
       ServiceNamespace: 'ecs'
       StepScalingPolicyConfiguration:
@@ -166,7 +169,7 @@ Resources:
         Fn::Join:
           - '/'
           - - scale
-            - '{{service_instance.unique_name}}'
+            - '{{service_name}}_{{service_instance_name}}'
             - up
       PolicyType: StepScaling
       ResourceId:
@@ -174,7 +177,7 @@ Resources:
           - '/'
           - - service
             - '{{environment.ClusterName}}'
-            - '{{service_instance.unique_name}}'
+            - '{{service_name}}_{{service_instance_name}}'
       ScalableDimension: 'ecs:service:DesiredCount'
       ServiceNamespace: 'ecs'
       StepScalingPolicyConfiguration:
@@ -199,17 +202,17 @@ Resources:
         Fn::Join:
           - '-'
           - - low-cpu
-            - '{{service_instance.unique_name}}'
+            - '{{service_name}}_{{service_instance_name}}'
       AlarmDescription:
         Fn::Join:
           - ' '
           - - "Low CPU utilization for service"
-            - '{{service_instance.unique_name}}'
+            - '{{service_name}}_{{service_instance_name}}'
       MetricName: CPUUtilization
       Namespace: AWS/ECS
       Dimensions:
         - Name: ServiceName
-          Value: '{{service_instance.unique_name}}'
+          Value: '{{service_name}}_{{service_instance_name}}'
         - Name: ClusterName
           Value:
             '{{environment.ClusterName}}'
@@ -228,17 +231,17 @@ Resources:
         Fn::Join:
           - '-'
           - - high-cpu
-            - '{{service_instance.unique_name}}'
+            - '{{service_name}}_{{service_instance_name}}'
       AlarmDescription:
         Fn::Join:
           - ' '
           - - "High CPU utilization for service"
-            - '{{service_instance.unique_name}}'
+            - '{{service_name}}_{{service_instance_name}}'
       MetricName: CPUUtilization
       Namespace: AWS/ECS
       Dimensions:
         - Name: ServiceName
-          Value: '{{service_instance.unique_name}}'
+          Value: '{{service_name}}_{{service_instance_name}}'
         - Name: ClusterName
           Value:
             '{{environment.ClusterName}}'

--- a/loadbalanced-fargate-svc/service/schema/schema.yaml
+++ b/loadbalanced-fargate-svc/service/schema/schema.yaml
@@ -31,13 +31,6 @@ schema:
           default: "public.ecr.aws/z9d2n7e1/nginx:1.19.5"
           minLength: 1
           maxLength: 200
-        unique_name:
-          type: string
-          description: "The unique name of your service identifier. This will be used to name your log group, task definition and ECS service"
-          minLength: 1
-          maxLength: 100
-      required:
-        - unique_name
 
     PipelineInputs:
       type: object

--- a/loadbalanced-fargate-svc/specs/svc-spec.yaml
+++ b/loadbalanced-fargate-svc/specs/svc-spec.yaml
@@ -10,4 +10,3 @@ instances:
       desired_count: 2
       port: 80
       task_size: "medium"
-      unique_name: "frontend-dev"


### PR DESCRIPTION
The unique_name parameter was needed because we only had access to the
parameters from {{environment}} and everything under `spec` in the
specs file.

Service templates now have access to two new variables,
`{{service_name}}` and `{{service_instance_name}}`.

In this example we used a `unique_name` parameter, which happened to
be a duplicate value of the service instance name. This parameter was
used for resources such as log group names, which need to be
unique. We can now use `{{service_instance_name}}` instead, without
the need to specify this `unique_name` attribute.

All usages of `{{unique_name}}` in the cfn template file have been
replaced by a combination of `{{service_name}}` and
`{{service_instance_name}}`, except the one for the container name.

Prefixing most usages with `{{service_name}}` will result in these
resources being named `front-end_frontend-dev`. This will be a
recommended approach over only using `{{service_instance_name}}` and
in this case resulting in `frontend-dev` since the same instance name
might used across multiple services. The target group is an exception
since their name does not allow `_`, so we use a double hyphen to
separate the service name from the service instance name.

The container resource does not need this since its parent task
definition is created within a family already named with the
service/service_instance prefix, so it would be redundant to prefix
the container name with the service name. The service instance name is
enough.

---

Important note!

Some resource names, such as for SQS queues and Target Groups have
uniqueness constraints in the region they're created in, while also
having short length limits, respectively 32 and 80 characters.

Using either `{{service_name}}`, `{{service_instance_name}}` or a
combination of the two could result in exceeding these limits. In this
case, the workaround would be to resort to the approach previously
used here with `{{unique_name}}`. For instance, customers would need
to add a `{{target_group_name}}` input and specify its value in the
service specs file for each service instance.

---

This commits addresses the request from
https://github.com/aws/aws-proton-public-roadmap/issues/29

*Issue #, if available:* https://github.com/aws/aws-proton-public-roadmap/issues/29

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

---

Tested by following the instructions on my branch and successfully deploying the service.
