### PR TITLE
fix: restrict unique_name to 32chars to match TargetGroup.Name limit

### DIFF
--- a/loadbalanced-fargate-svc/service/schema/schema.yaml
+++ b/loadbalanced-fargate-svc/service/schema/schema.yaml
@@ -35,7 +35,7 @@ schema:
           type: string
           description: "The unique name of your service identifier. This will be used to name your log group, task definition and ECS service"
           minLength: 1
-          maxLength: 100
+          maxLength: 32
       required:
         - unique_name
 


### PR DESCRIPTION
*Description of changes:*
Cloudformation Stack fails if this is > 32chars. 

The maxLength of 100 interferes with the restriction of 32 characters for a `AWS::ElasticLoadBalancingV2::TargetGroup` (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-name). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
