### PR TITLE
adding sample templates for Fargate microservices workloads

### DIFF
--- a/public-private-fargate-microservices/README.md
+++ b/public-private-fargate-microservices/README.md
@@ -1,0 +1,404 @@
+# AWS Proton Sample Microservices Using Amazon ECS and AWS Fargate
+
+This directory contains a sample AWS Proton Environment and Service templates for a set of Amazon ECS based microservices using service discovery running on AWS Fargate, as well as sample specs for creating Proton Environments and Services using the templates. All resources deployed are tagged.
+
+The environment template deploys:
+
+- a VPC
+- an Internet Gateway
+- 2 Nat Gateways across 2 Availability Zones
+- 2 private subnets across 2 Availability Zones
+- 2 public subnets across 2 Availability Zones
+- an ECS Cluster
+- a private namespace for service discovery
+
+The service templates contains all the resources required to create a public ECS Fargate service behind a load balancer and a private ECS Fargate service in that environment. It also provides sample specs for creating Proton Environments and Services using the templates.
+
+Developers provisioning their services can configure the following properties through their service spec:
+
+- Fargate CPU size
+- Fargate memory size
+- Number of running containers
+- Choose private or public subnets to run the loadbalanced service or the private service, accessed via service discovery
+- Service name to register and use for service discovery
+
+# Registering and deploying these templates
+
+You can register and deploy these templates by using the AWS Proton console. To do this, you will need to compress the templates using the instructions below, upload them to an S3 bucket, and use the Proton console to register and test them. If you prefer to use the Command Line Interface, follow the instructions below:
+
+## Prerequisites
+
+First, make sure you have the AWS CLI installed, and configured. Run the following command to set an environment variable with your account ID:
+
+```
+account_id=`aws sts get-caller-identity|jq -r ".Account"`
+```
+
+### Configure the AWS CLI
+
+While AWS Proton is in preview, you will need to manually configure the AWS CLI. The following commands will add the Proton commands to the AWS CLI.
+
+```
+aws s3 cp s3://aws-proton-preview-public-files/model/proton-2020-07-20.normal.json .
+aws s3 cp s3://aws-proton-preview-public-files/model/waiters2.json .
+aws configure add-model --service-model file://proton-2020-07-20.normal.json --service-name proton-preview
+mv waiters2.json ~/.aws/models/proton-preview/2020-07-20/waiters-2.json
+rm proton-2020-07-20.normal.json
+```
+
+### Configure IAM Role, S3 Bucket, and CodeStar Connections Connection
+
+Before you register your templates and deploy your environments and services, you will need to create an Amazon IAM role so that AWS Proton can manage resources in your AWS account, an Amazon S3 bucket to store your templates, and a CodeStar Connections connection to pull and deploy your application code.
+
+Create the S3 bucket to store your templates:
+
+```
+aws s3api create-bucket \
+  --region us-east-2 \
+  --bucket "proton-cli-templates-${account_id}" \
+  --create-bucket-configuration LocationConstraint=us-east-2
+```
+
+Create the IAM role that Proton will assume to provision resources and manage AWS CloudFormation stacks in your AWS account.
+
+```
+aws iam create-role \
+  --role-name ProtonServiceRole \
+  --assume-role-policy-document file://./policies/proton-service-assume-policy.json
+
+aws iam attach-role-policy \
+  --role-name ProtonServiceRole \
+  --policy-arn arn:aws:iam::aws:policy/AdministratorAccess
+```
+
+Then, allow Proton to use that role to provision resources for your services' continuous delivery pipelines:
+
+```
+aws proton-preview update-account-roles \
+  --region us-east-2 \
+  --account-role-details "pipelineServiceRoleArn=arn:aws:iam::${account_id}:role/ProtonServiceRole"
+```
+
+Create an AWS CodeStar Connections connection to your application code stored in a GitHub or Bitbucket source code repository.  This connection allows CodePipeline to pull your application source code before building and deploying the code to your Proton service. To use sample application code for the public service, first create a fork of the sample application repository here:
+https://github.com/aws-samples/aws-proton-sample-fargate-service
+
+Creating the source code connection must be completed in the CodeStar Connections console:
+https://us-east-2.console.aws.amazon.com/codesuite/settings/connections?region=us-east-2
+
+## Register an Environment Template
+
+Register the sample environment template, which contains an ECS Cluster and a VPC with two public subnets.
+
+First, create an environment template, which will contain all of the environment template's major and minor versions.
+
+```
+aws proton-preview \
+  --endpoint-url https://proton.us-east-2.amazonaws.com \
+  --region us-east-2 \
+  create-environment-template \
+  --template-name "aws-proton-fargate-microservices" \
+  --display-name "aws proton fargate microservices" \
+  --description "Proton Example Dev VPC with Public facing services and with Private backend services on ECS cluster with Fargate compute"
+```
+
+Then, create a new major version for the `aws-proton-fargate-microservices` environment template.
+
+```
+aws proton-preview \
+  --endpoint-url https://proton.us-east-2.amazonaws.com \
+  --region us-east-2 \
+  create-environment-template-major-version \
+  --template-name "aws-proton-fargate-microservices" \
+  --description "Version 1"
+```
+
+Now create a minor version which contains the contents of the sample environment template. Compress the sample template files and register the minor version:
+
+```
+tar -zcvf env-template.tar.gz environment/
+
+aws s3 cp env-template.tar.gz s3://proton-cli-templates-${account_id}/env-template.tar.gz --region us-east-2
+
+rm env-template.tar.gz
+
+aws proton-preview \
+  --endpoint-url https://proton.us-east-2.amazonaws.com \
+  --region us-east-2 \
+  create-environment-template-minor-version \
+  --template-name "aws-proton-fargate-microservices" \
+  --description "Proton Example Dev Environment Version 1" \
+  --major-version-id "1" \
+  --source-s3-bucket proton-cli-templates-${account_id} \
+  --source-s3-key env-template.tar.gz
+```
+
+Wait for the environment template minor version to be successfully registered:
+
+```
+aws proton-preview wait environment-template-registration-complete \
+  --region us-east-2 \
+  --template-name "aws-proton-fargate-microservices" \
+  --major-version-id "1" \
+  --minor-version-id "0"
+```
+
+You can now publish the environment template minor version, making it available for users in your AWS account to create Proton environments.
+
+```
+aws proton-preview \
+  --endpoint-url https://proton.us-east-2.amazonaws.com \
+  --region us-east-2 \
+  update-environment-template-minor-version \
+  --template-name "aws-proton-fargate-microservices" \
+  --major-version-id "1" \
+  --minor-version-id "0" \
+  --status "PUBLISHED"
+```
+
+## Register the Service Templates
+
+Register the sample services templates, which contains all the resources required to provision an ECS Fargate services behind a load balancer, the private services as well as a continuous delivery pipeline using AWS CodePipeline for each.
+
+### First, create the Public service template.
+
+```
+aws proton-preview \
+  --endpoint-url https://proton.us-east-2.amazonaws.com \
+  --region us-east-2 \
+  create-service-template \
+  --template-name "lb-public-fargate-svc" \
+  --display-name "PublicLoadbalancedFargateService" \
+  --description "Fargate Service with an Application Load Balancer"
+```
+
+Then, create a major version for the `lb-public-fargate-service` service template and associate it with the `aws-proton-fargate-microservices` environment template created above.
+
+```
+aws proton-preview \
+  --endpoint-url https://proton.us-east-2.amazonaws.com \
+  --region us-east-2 \
+  create-service-template-major-version \
+  --template-name "lb-public-fargate-svc" \
+  --description "Version 1" \
+  --compatible-environment-template-major-version-arns arn:aws:proton:us-east-2:${account_id}:environment-template/aws-proton-fargate-microservices:1
+```
+
+Now create a minor version which contains the contents of the sample service template. Compress the sample template files and register the minor version:
+
+```
+tar -zcvf svc-private-template.tar.gz service/loadbalanced-public-svc/
+
+aws s3 cp svc-private-template.tar.gz s3://proton-cli-templates-${account_id}/svc-private-template.tar.gz
+
+rm svc-private-template.tar.gz
+
+aws proton-preview \
+  --endpoint-url https://proton.us-east-2.amazonaws.com \
+  --region us-east-2 \
+  create-service-template-minor-version \
+  --template-name "lb-public-fargate-svc" \
+  --description "Version 1" \
+  --major-version-id "1" \
+  --source-s3-bucket proton-cli-templates-${account_id} \
+  --source-s3-key svc-private-template.tar.gz
+```
+
+Wait for the service template minor version to be successfully registered:
+
+```
+aws proton-preview \
+  --endpoint-url https://proton.us-east-2.amazonaws.com \
+  --region us-east-2 \
+  wait service-template-registration-complete \
+  --template-name "lb-public-fargate-svc" \
+  --major-version-id "1" \
+  --minor-version-id "0"
+```
+
+You can now publish the Public service template minor version, making it available for users in your AWS account to create Proton services.
+
+```
+aws proton-preview \
+  --endpoint-url https://proton.us-east-2.amazonaws.com \
+  --region us-east-2 \
+  update-service-template-minor-version \
+  --template-name "lb-public-fargate-svc" \
+  --major-version-id "1" \
+  --minor-version-id "0" \
+  --status "PUBLISHED"
+```
+
+### Second, create the Private service template.
+
+```
+aws proton-preview \
+  --endpoint-url https://proton.us-east-2.amazonaws.com \
+  --region us-east-2 \
+  create-service-template \
+  --template-name "private-fargate-svc" \
+  --display-name "PrivateBackendFargateService" \
+  --description "Private Backend Fargate Service"
+```
+
+Then, create a major version for the `private-fargate-service` service template and associate it with the `aws-proton-fargate-microservices` environment template created above.
+
+```
+aws proton-preview \
+  --endpoint-url https://proton.us-east-2.amazonaws.com \
+  --region us-east-2 \
+  create-service-template-major-version \
+  --template-name "private-fargate-svc" \
+  --description "Version 1" \
+  --compatible-environment-template-major-version-arns arn:aws:proton:us-east-2:${account_id}:environment-template/aws-proton-fargate-microservices:1
+```
+
+Now create a minor version which contains the contents of the sample service template. Compress the sample template files and register the minor version:
+
+```
+tar -zcvf svc-private-template.tar.gz service/private-fargate-svc/
+
+aws s3 cp svc-private-template.tar.gz s3://proton-cli-templates-${account_id}/svc-private-template.tar.gz
+
+rm svc-private-template.tar.gz
+
+aws proton-preview \
+  --endpoint-url https://proton.us-east-2.amazonaws.com \
+  --region us-east-2 \
+  create-service-template-minor-version \
+  --template-name "private-fargate-svc" \
+  --description "Version 1" \
+  --major-version-id "1" \
+  --source-s3-bucket proton-cli-templates-${account_id} \
+  --source-s3-key svc-private-template.tar.gz
+```
+
+Wait for the service template minor version to be successfully registered:
+
+```
+aws proton-preview \
+  --endpoint-url https://proton.us-east-2.amazonaws.com \
+  --region us-east-2 \
+  wait service-template-registration-complete \
+  --template-name "private-fargate-svc" \
+  --major-version-id "1" \
+  --minor-version-id "0"
+```
+
+You can now publish the Public service template minor version, making it available for users in your AWS account to create Proton services.
+
+```
+aws proton-preview \
+  --endpoint-url https://proton.us-east-2.amazonaws.com \
+  --region us-east-2 \
+  update-service-template-minor-version \
+  --template-name "private-fargate-svc" \
+  --major-version-id "1" \
+  --minor-version-id "0" \
+  --status "PUBLISHED"
+```
+
+## Deploy An Environment and Services
+
+With the registered and published environment and service templates, you can now instantiate a Proton environment and service from the templates.
+
+First, deploy a Proton environment. This command reads your environment spec at `specs/env-spec.yaml`, merges it with the environment template created above, and deploys the resources in a CloudFormation stack in your AWS account using the Proton service role.
+
+```
+aws proton-preview create-environment \
+  --region us-east-2 \
+  --environment-name "Beta" \
+  --environment-template-arn arn:aws:proton:us-east-2:${account_id}:environment-template/aws-proton-fargate-microservices \
+  --template-major-version-id 1 \
+  --proton-service-role-arn arn:aws:iam::${account_id}:role/ProtonServiceRole \
+  --spec file://specs/env-spec.yaml
+```
+
+Wait for the environment to successfully deploy.
+
+```
+aws proton-preview wait environment-deployment-complete \
+  --region us-east-2 \
+  --environment-name "Beta"
+```
+
+Then, create a Public Proton service and deploy it into your Proton environment.  This command reads your service spec at `specs/svc-public-spec.yaml`, merges it with the service template created above, and deploys the resources in CloudFormation stacks in your AWS account using the Proton service role.  The service will provision a load-balanced ECS service running on Fargate and a CodePipeline pipeline to deploy your application code.
+
+Fill in your CodeStar Connections connection ID and your source code repository details in this command.
+
+```
+aws proton-preview create-service \
+  --region us-east-2 \
+  --service-name "front-end" \
+  --repository-connection-arn arn:aws:codestar-connections:us-east-2:${account_id}:connection/<your-codestar-connection-id> \
+  --repository-id "<your-source-repo-account>/<your-repository-name>" \
+  --branch "main" \
+  --template-major-version-id 1 \
+  --service-template-arn arn:aws:proton:us-east-2:${account_id}:service-template/lb-public-fargate-svc \
+  --spec file://specs/svc-public-spec.yaml
+```
+
+Wait for the service to successfully deploy.
+
+```
+aws proton-preview wait service-creation-complete \
+  --region us-east-2 \
+  --service-name "front-end"
+```
+
+Once the service is created, retrieve the CodePipeline pipeline console URL and the CRUD API endpoint URL for your service.
+
+```
+aws proton-preview get-service \
+  --region us-east-2 \
+  --service-name "front-end" \
+  --query "service.pipeline.outputs" \
+  --output text
+
+aws proton-preview get-service-instance \
+  --region us-east-2 \
+  --service-name "front-end" \
+  --service-instance-name "frontend-dev" \
+  --query "serviceInstance.outputs" \
+  --output text
+```
+
+And finally, create a Private Proton service and deploy it into your Proton environment.  This command reads your service spec at `specs/svc-private-spec.yaml`, merges it with the service template created above, and deploys the resources in CloudFormation stacks in your AWS account using the Proton service role. The service will provision a private ECS service running on Fargate and a CodePipeline pipeline to deploy your application code.
+
+Fill in your CodeStar Connections connection ID and your source code repository details in this command.
+
+```
+aws proton-preview create-service \
+  --region us-east-2 \
+  --service-name "back-end" \
+  --repository-connection-arn arn:aws:codestar-connections:us-east-2:${account_id}:connection/<your-codestar-connection-id> \
+  --repository-id "<your-source-repo-account>/<your-repository-name>" \
+  --branch "main" \
+  --template-major-version-id 1 \
+  --service-template-arn arn:aws:proton:us-east-2:${account_id}:service-template/lb-private-fargate-svc \
+  --spec file://specs/svc-private-spec.yaml
+```
+
+Wait for the service to successfully deploy.
+
+```
+aws proton-preview wait service-creation-complete \
+  --region us-east-2 \
+  --service-name "back-end"
+```
+
+Once the service is created, retrieve the CodePipeline pipeline console URL and the CRUD API endpoint URL for your service.
+
+```
+aws proton-preview get-service \
+  --region us-east-2 \
+  --service-name "back-end" \
+  --query "service.pipeline.outputs" \
+  --output text
+
+aws proton-preview get-service-instance \
+  --region us-east-2 \
+  --service-name "back-end" \
+  --service-instance-name "backend-dev" \
+  --query "serviceInstance.outputs" \
+  --output text
+```

--- a/public-private-fargate-microservices/environment/infrastructure/cloudformation.yaml
+++ b/public-private-fargate-microservices/environment/infrastructure/cloudformation.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: AWS Fargate cluster running containers in a public subnet. Only supports
-             public facing load balancer, and public service discovery namespaces.
+Description: AWS Fargate cluster running containers in public and private subnets. Supports
+             public facing microservices behind load balancer, private microservices, and private service discovery namespaces. Deployed resources are all tagged with defined environment name tag.
 Mappings:
   # The VPC and subnet configuration is passed in via the environment spec.
   EnvironmentNameConfig:

--- a/public-private-fargate-microservices/environment/infrastructure/cloudformation.yaml
+++ b/public-private-fargate-microservices/environment/infrastructure/cloudformation.yaml
@@ -1,0 +1,282 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: AWS Fargate cluster running containers in a public subnet. Only supports
+             public facing load balancer, and public service discovery namespaces.
+Mappings:
+  # The VPC and subnet configuration is passed in via the environment spec.
+  EnvironmentNameConfig:
+    Environment: 
+      Name: '{{ environment.environment_name_tag}}'
+  SubnetConfig:
+    VPC:
+      CIDR: '{{ environment.vpc_cidr}}'
+    PublicOne:
+      CIDR: '{{ environment.public_subnet_one_cidr}}'
+    PublicTwo:
+      CIDR: '{{ environment.public_subnet_two_cidr}}'
+    PrivateOne:
+      CIDR: '{{ environment.private_subnet_one_cidr}}'
+    PrivateTwo:
+      CIDR: '{{ environment.private_subnet_two_cidr}}'
+  ServiceDiscoveryConfig:
+    PrivateNamespace:
+      Name: '{{ environment.service_discovery_namespace}}'
+
+Resources:
+ # Create the VPC with subnets across 2 Availability Zones, 2 Public subnets, 2 Private subnets, 
+ # an Internet Gateway, 2 Nat Gateways and the required routetables and routes
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !FindInMap ['SubnetConfig', 'VPC', 'CIDR']
+      Tags:
+        - Key: Name
+          Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
+            
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
+          
+  InternetGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      InternetGatewayId: !Ref InternetGateway
+      VpcId: !Ref VPC
+
+  PublicSubnetOne: 
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      AvailabilityZone:
+        Fn::Select:
+        - 0
+        - Fn::GetAZs: {Ref: 'AWS::Region'}
+      CidrBlock: !FindInMap ['SubnetConfig', 'PublicOne', 'CIDR']
+      MapPublicIpOnLaunch: true
+      Tags: 
+        - Key: Name 
+          Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
+
+  PublicSubnetTwo: 
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      AvailabilityZone:
+        Fn::Select:
+        - 1
+        - Fn::GetAZs: {Ref: 'AWS::Region'}
+      CidrBlock: !FindInMap ['SubnetConfig', 'PublicTwo', 'CIDR']
+      MapPublicIpOnLaunch: true
+      Tags: 
+        - Key: Name 
+          Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
+
+  PrivateSubnetOne: 
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      AvailabilityZone:
+        Fn::Select:
+        - 0
+        - Fn::GetAZs: {Ref: 'AWS::Region'}
+      CidrBlock: !FindInMap ['SubnetConfig', 'PrivateOne', 'CIDR']
+      MapPublicIpOnLaunch: false
+      Tags: 
+        - Key: Name 
+          Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
+
+  PrivateSubnetTwo: 
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      AvailabilityZone:
+        Fn::Select:
+        - 1
+        - Fn::GetAZs: {Ref: 'AWS::Region'}
+      CidrBlock: !FindInMap ['SubnetConfig', 'PrivateTwo', 'CIDR']
+      MapPublicIpOnLaunch: false
+      Tags: 
+        - Key: Name 
+          Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
+
+  NatGatewayOneEIP:
+    Type: AWS::EC2::EIP
+    DependsOn: InternetGatewayAttachment
+    Properties: 
+      Domain: vpc
+      Tags: 
+        - Key: Name 
+          Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
+
+  NatGatewayTwoEIP:
+    Type: AWS::EC2::EIP
+    DependsOn: InternetGatewayAttachment
+    Properties:
+      Domain: vpc
+      Tags: 
+        - Key: Name 
+          Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
+
+  NatGatewayOne: 
+    Type: AWS::EC2::NatGateway
+    Properties: 
+      AllocationId: !GetAtt NatGatewayOneEIP.AllocationId
+      SubnetId: !Ref PublicSubnetOne
+      Tags: 
+        - Key: Name 
+          Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
+
+  NatGatewayTwo: 
+    Type: AWS::EC2::NatGateway
+    Properties:
+      AllocationId: !GetAtt NatGatewayTwoEIP.AllocationId
+      SubnetId: !Ref PublicSubnetTwo
+      Tags: 
+        - Key: Name 
+          Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
+
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties: 
+      VpcId: !Ref VPC
+      Tags: 
+        - Key: Name 
+          Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
+
+  DefaultPublicRoute: 
+    Type: AWS::EC2::Route
+    DependsOn: InternetGatewayAttachment
+    Properties: 
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  PublicSubnetOneRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref PublicSubnetOne
+
+  PublicSubnetTwoRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref PublicSubnetTwo
+
+  PrivateRouteTableOne:
+    Type: AWS::EC2::RouteTable
+    Properties: 
+      VpcId: !Ref VPC
+      Tags: 
+        - Key: Name 
+          Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
+
+  DefaultPrivateRouteOne:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PrivateRouteTableOne
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: !Ref NatGatewayOne
+
+  PrivateSubnetOneRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PrivateRouteTableOne
+      SubnetId: !Ref PrivateSubnetOne
+
+  PrivateRouteTableTwo:
+    Type: AWS::EC2::RouteTable
+    Properties: 
+      VpcId: !Ref VPC
+      Tags: 
+        - Key: Name 
+          Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
+
+  DefaultPrivateRouteTwo:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PrivateRouteTableTwo
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: !Ref NatGatewayTwo
+
+  PrivateSubnetTwoRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PrivateRouteTableTwo
+      SubnetId: !Ref PrivateSubnetTwo
+
+  # Create a Private namespace for Service Discovery
+  PrivateNamespace:
+    Type: AWS::ServiceDiscovery::PrivateDnsNamespace
+    Properties:
+      Name: !FindInMap ['ServiceDiscoveryConfig', 'PrivateNamespace', 'Name']
+      Vpc: !Ref 'VPC'
+
+  # Create the ECS Cluster to schedule and orchestrate the Fargate containers
+  ECSCluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      Tags: 
+        - Key: Name 
+          Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
+
+  # A security group for the containers we will run in Fargate.
+  # Rules are added to this security group based on what ingress you
+  # add for the cluster.
+  ContainerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Access to the Fargate containers
+      VpcId: !Ref 'VPC'
+      Tags: 
+        - Key: Name 
+          Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
+
+  # This is a role which is used by the ECS tasks themselves.
+  ECSTaskExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: [ecs-tasks.amazonaws.com]
+          Action: ['sts:AssumeRole']
+      Path: /
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'
+      Tags: 
+        - Key: Name 
+          Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
+
+# These output values will be available to service templates to use.
+Outputs:
+  ClusterName:
+    Description: The name of the ECS cluster
+    Value: !Ref 'ECSCluster'
+  ECSTaskExecutionRole:
+    Description: The ARN of the ECS role
+    Value: !GetAtt 'ECSTaskExecutionRole.Arn'
+  VpcId:
+    Description: The ID of the VPC that this stack is deployed in
+    Value: !Ref 'VPC'
+  PublicSubnetOne:
+    Description: A reference to the public subnet in the 1st Availability Zone
+    Value: !Ref 'PublicSubnetOne'
+  PublicSubnetTwo:
+    Description: A reference to the public subnet in the 2nd Availability Zone
+    Value: !Ref 'PublicSubnetTwo'
+  PrivateSubnetOne:
+    Description: A reference to the private subnet in the 1st Availability Zone
+    Value: !Ref 'PrivateSubnetOne'
+  PrivateSubnetTwo:
+    Description: A reference to the private subnet in the 2nd Availability Zone
+    Value: !Ref 'PrivateSubnetTwo'
+  ContainerSecurityGroup:
+    Description: A security group used to allow Fargate containers to receive traffic
+    Value: !Ref 'ContainerSecurityGroup'
+  PrivateNamespace:
+    Description: The NamespaceId registered for Service Discovery
+    Value: !Ref 'PrivateNamespace'

--- a/public-private-fargate-microservices/environment/infrastructure/manifest.yaml
+++ b/public-private-fargate-microservices/environment/infrastructure/manifest.yaml
@@ -1,0 +1,5 @@
+infrastructure:
+  templates:
+    - file: "cloudformation.yaml"
+      engine: jinja
+      template_language: cloudformation

--- a/public-private-fargate-microservices/environment/schema/schema.yaml
+++ b/public-private-fargate-microservices/environment/schema/schema.yaml
@@ -1,0 +1,43 @@
+schema:
+  format:
+    openapi: "3.0.0"
+  environment_input_type: "PublicEnvironmentInput"
+  types:
+    PublicEnvironmentInput:
+      type: object
+      description: "Input properties for my environment"
+      properties:
+        environment_name_tag:
+          type: string
+          description: "The Name tag to the add to the VPC resources"
+          default: AWS Proton Environment
+        vpc_cidr:
+          type: string
+          description: "This CIDR range for your VPC"
+          default: 10.0.0.0/16
+          pattern: ([0-9]{1,3}\.){3}[0-9]{1,3}($|/(16|24))
+        public_subnet_one_cidr:
+          type: string
+          description: "The CIDR range for public subnet one"
+          default: 10.0.1.0/24
+          pattern: ([0-9]{1,3}\.){3}[0-9]{1,3}($|/(16|24))
+        public_subnet_two_cidr:
+          type: string
+          description: "The CIDR range for public subnet one"
+          default: 10.0.2.0/24
+          pattern: ([0-9]{1,3}\.){3}[0-9]{1,3}($|/(16|24))
+        private_subnet_one_cidr:
+          type: string
+          description: "The CIDR range for private subnet one"
+          default: 10.0.3.0/24
+          pattern: ([0-9]{1,3}\.){3}[0-9]{1,3}($|/(16|24))
+        private_subnet_two_cidr:
+          type: string
+          description: "The CIDR range for private subnet two"
+          default: 10.0.4.0/24
+          pattern: ([0-9]{1,3}\.){3}[0-9]{1,3}($|/(16|24))
+        service_discovery_namespace:
+          type: string
+          description: "The name of the private namespace for service discovery"
+          default: example.local
+

--- a/public-private-fargate-microservices/policies/proton-service-assume-policy.json
+++ b/public-private-fargate-microservices/policies/proton-service-assume-policy.json
@@ -1,0 +1,12 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "proton.amazonaws.com"
+        },
+        "Action": "sts:AssumeRole"
+      }
+    ]
+  }

--- a/public-private-fargate-microservices/service/loadbalanced-public-svc/infrastructure/cloudformation.yaml
+++ b/public-private-fargate-microservices/service/loadbalanced-public-svc/infrastructure/cloudformation.yaml
@@ -1,0 +1,345 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Deploy a service on AWS Fargate, hosted in a public subnet, and accessible via a public load balancer.
+Mappings:
+  EnvironmentNameConfig:
+    Environment: 
+      Name: '{{ environment.environment_name_tag}}'
+  TaskSize:
+    x-small:
+      cpu: 256
+      memory: 512
+    small:
+      cpu: 512
+      memory: 1024
+    medium:
+      cpu: 1024
+      memory: 2048
+    large:
+      cpu: 2048
+      memory: 4096
+    x-large:
+      cpu: 4096
+      memory: 8192
+Resources:
+  # Register service in ServiceDiscovery Service
+  DiscoveryService:
+    Type: AWS::ServiceDiscovery::Service
+    Properties:
+      Description: Discovery Service for the Demo Application
+      DnsConfig:
+        RoutingPolicy: MULTIVALUE
+        DnsRecords:
+          - TTL: 60
+            Type: A
+          - TTL: 60
+            Type: SRV
+      HealthCheckCustomConfig:
+        FailureThreshold: 1
+      Name: '{{service_instance.service_discovery_name}}'
+      NamespaceId: '{{environment.PrivateNamespace}}'
+
+  # A log group for storing the stdout logs from this service's containers
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: '{{service_instance.unique_name}}'
+
+  # The task definition. This is a simple metadata description of what
+  # container to run, and what resource requirements it has.
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: '{{service_instance.unique_name}}'
+      Cpu: !FindInMap [TaskSize, {{service_instance.task_size}}, cpu]
+      Memory: !FindInMap [TaskSize, {{service_instance.task_size}}, memory]
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      ExecutionRoleArn: '{{environment.ECSTaskExecutionRole}}'
+      TaskRoleArn: !Ref "AWS::NoValue"
+      ContainerDefinitions:
+        - Name: '{{service_instance.unique_name}}'
+          Cpu: !FindInMap [TaskSize, {{service_instance.task_size}}, cpu]
+          Memory: !FindInMap [TaskSize, {{service_instance.task_size}}, memory]
+          Image: '{{service_instance.image}}'
+          PortMappings:
+            - ContainerPort: '{{service_instance.port}}'
+          LogConfiguration:
+            LogDriver: 'awslogs'
+            Options:
+              awslogs-group: '{{service_instance.unique_name}}'
+              awslogs-region: !Ref 'AWS::Region'
+              awslogs-stream-prefix: '{{service_instance.unique_name}}'
+      Tags: 
+        - Key: Name 
+          Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
+
+  # The service_instance. The service is a resource which allows you to run multiple
+  # copies of a type of task, and gather up their logs and metrics, as well
+  # as monitor the number of running tasks and replace any that have crashed
+  Service:
+    Type: AWS::ECS::Service
+    DependsOn: LoadBalancerRule
+    Properties:
+      ServiceName: '{{service_instance.unique_name}}'
+      Cluster: '{{environment.ClusterName}}'
+      LaunchType: FARGATE
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 75
+      DesiredCount: '{{service_instance.desired_count}}'
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
+          SecurityGroups:
+            - '{{environment.ContainerSecurityGroup}}'
+          Subnets:
+            - '{{environment.PublicSubnetOne}}'
+            - '{{environment.PublicSubnetTwo}}'
+      TaskDefinition: !Ref 'TaskDefinition'
+      ServiceRegistries:
+      - RegistryArn: !GetAtt DiscoveryService.Arn
+        Port: 80
+      LoadBalancers:
+        - ContainerName: '{{service_instance.unique_name}}'
+          ContainerPort: '{{service_instance.port}}'
+          TargetGroupArn: !Ref 'TargetGroup'
+      Tags: 
+        - Key: Name 
+          Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
+
+  # A target group. This is used for keeping track of all the tasks, and
+  # what IP addresses / port numbers they have. You can query it yourself,
+  # to use the addresses yourself, but most often this target group is just
+  # connected to an application load balancer, or network load balancer, so
+  # it can automatically distribute traffic across all the targets.
+  TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 6
+      HealthCheckPath: /
+      HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 2
+      TargetType: ip
+      Name: '{{service_instance.unique_name}}'
+      Port: '{{service_instance.port}}'
+      Protocol: HTTP
+      UnhealthyThresholdCount: 2
+      VpcId: '{{environment.VpcId}}'
+      Tags: 
+        - Key: Name 
+          Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
+
+  # Create a rule on the load balancer for routing traffic to the target group
+  LoadBalancerRule:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Properties:
+      Actions:
+        - TargetGroupArn: !Ref 'TargetGroup'
+          Type: 'forward'
+      Conditions:
+        - Field: path-pattern
+          Values:
+            - '*'
+      ListenerArn: !Ref PublicLoadBalancerListener
+      Priority: 1
+
+  # Enable autoscaling for this service
+  ScalableTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    DependsOn: Service
+    Properties:
+      ServiceNamespace: 'ecs'
+      ScalableDimension: 'ecs:service:DesiredCount'
+      ResourceId:
+        Fn::Join:
+          - '/'
+          - - service
+            - '{{environment.ClusterName}}'
+            - '{{service_instance.unique_name}}'
+      MinCapacity: 1
+      MaxCapacity: 10
+      RoleARN: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService
+
+  # Create scaling policies for the service
+  ScaleDownPolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    DependsOn: ScalableTarget
+    Properties:
+      PolicyName:
+        Fn::Join:
+          - '/'
+          - - scale
+            - '{{service_instance.unique_name}}'
+            - down
+      PolicyType: StepScaling
+      ResourceId:
+        Fn::Join:
+          - '/'
+          - - service
+            - '{{environment.ClusterName}}'
+            - '{{service_instance.unique_name}}'
+      ScalableDimension: 'ecs:service:DesiredCount'
+      ServiceNamespace: 'ecs'
+      StepScalingPolicyConfiguration:
+        AdjustmentType: 'ChangeInCapacity'
+        StepAdjustments:
+          - MetricIntervalUpperBound: 0
+            ScalingAdjustment: -1
+        MetricAggregationType: 'Average'
+        Cooldown: 60
+
+  ScaleUpPolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    DependsOn: ScalableTarget
+    Properties:
+      PolicyName:
+        Fn::Join:
+          - '/'
+          - - scale
+            - '{{service_instance.unique_name}}'
+            - up
+      PolicyType: StepScaling
+      ResourceId:
+        Fn::Join:
+          - '/'
+          - - service
+            - '{{environment.ClusterName}}'
+            - '{{service_instance.unique_name}}'
+      ScalableDimension: 'ecs:service:DesiredCount'
+      ServiceNamespace: 'ecs'
+      StepScalingPolicyConfiguration:
+        AdjustmentType: 'ChangeInCapacity'
+        StepAdjustments:
+          - MetricIntervalLowerBound: 0
+            MetricIntervalUpperBound: 15
+            ScalingAdjustment: 1
+          - MetricIntervalLowerBound: 15
+            MetricIntervalUpperBound: 25
+            ScalingAdjustment: 2
+          - MetricIntervalLowerBound: 25
+            ScalingAdjustment: 3
+        MetricAggregationType: 'Average'
+        Cooldown: 60
+
+  # Create alarms to trigger these policies
+  LowCpuUsageAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        Fn::Join:
+          - '-'
+          - - low-cpu
+            - '{{service_instance.unique_name}}'
+      AlarmDescription:
+        Fn::Join:
+          - ' '
+          - - "Low CPU utilization for service"
+            - '{{service_instance.unique_name}}'
+      MetricName: CPUUtilization
+      Namespace: AWS/ECS
+      Dimensions:
+        - Name: ServiceName
+          Value: '{{service_instance.unique_name}}'
+        - Name: ClusterName
+          Value:
+            '{{environment.ClusterName}}'
+      Statistic: Average
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 20
+      ComparisonOperator: LessThanOrEqualToThreshold
+      AlarmActions:
+        - !Ref ScaleDownPolicy
+
+  HighCpuUsageAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        Fn::Join:
+          - '-'
+          - - high-cpu
+            - '{{service_instance.unique_name}}'
+      AlarmDescription:
+        Fn::Join:
+          - ' '
+          - - "High CPU utilization for service"
+            - '{{service_instance.unique_name}}'
+      MetricName: CPUUtilization
+      Namespace: AWS/ECS
+      Dimensions:
+        - Name: ServiceName
+          Value: '{{service_instance.unique_name}}'
+        - Name: ClusterName
+          Value:
+            '{{environment.ClusterName}}'
+      Statistic: Average
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 70
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmActions:
+        - !Ref ScaleUpPolicy
+
+  EcsSecurityGroupIngressFromPublicALB:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      Description: Ingress from the public ALB
+      GroupId: '{{environment.ContainerSecurityGroup}}'
+      IpProtocol: -1
+      SourceSecurityGroupId: !Ref 'PublicLoadBalancerSG'
+
+  # Public load balancer, hosted in public subnets that is accessible
+  # to the public, and is intended to route traffic to one or more public
+  # facing services. This is used for accepting traffic from the public
+  # internet and directing it to public facing microservices
+  PublicLoadBalancerSG:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Access to the public facing load balancer
+      VpcId: '{{environment.VpcId}}'
+      SecurityGroupIngress:
+          # Allow access to ALB from anywhere on the internet
+          - CidrIp: 0.0.0.0/0
+            IpProtocol: -1
+      Tags: 
+        - Key: Name 
+          Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
+
+  PublicLoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Scheme: internet-facing
+      LoadBalancerAttributes:
+      - Key: idle_timeout.timeout_seconds
+        Value: '30'
+      Subnets:
+        # The load balancer is placed into the public subnets, so that traffic
+        # from the internet can reach the load balancer directly via the internet gateway
+        - '{{environment.PublicSubnetOne}}'
+        - '{{environment.PublicSubnetTwo}}'
+      SecurityGroups: [!Ref 'PublicLoadBalancerSG']
+      Tags: 
+        - Key: Name 
+          Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
+
+  PublicLoadBalancerListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    DependsOn:
+      - PublicLoadBalancer
+    Properties:
+      DefaultActions:
+        - TargetGroupArn: !Ref 'TargetGroup'
+          Type: 'forward'
+      LoadBalancerArn: !Ref 'PublicLoadBalancer'
+      Port: 80
+      Protocol: HTTP
+
+Outputs:
+  ServiceEndpoint:
+    Description: The URL to access the service
+    Value: !Sub "http://${PublicLoadBalancer.DNSName}"
+  ServiceDiscovery:
+    Description: The registered service discovery Service Id
+    Value: !Ref DiscoveryService

--- a/public-private-fargate-microservices/service/loadbalanced-public-svc/infrastructure/cloudformation.yaml
+++ b/public-private-fargate-microservices/service/loadbalanced-public-svc/infrastructure/cloudformation.yaml
@@ -42,14 +42,14 @@ Resources:
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: '{{service_instance.unique_name}}'
+      LogGroupName: '{{service_name}}/{{service_instance_name}}'
 
   # The task definition. This is a simple metadata description of what
   # container to run, and what resource requirements it has.
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:
-      Family: '{{service_instance.unique_name}}'
+      Family: '{{service_name}}_{{service_instance_name}}'
       Cpu: !FindInMap [TaskSize, {{service_instance.task_size}}, cpu]
       Memory: !FindInMap [TaskSize, {{service_instance.task_size}}, memory]
       NetworkMode: awsvpc
@@ -58,7 +58,7 @@ Resources:
       ExecutionRoleArn: '{{environment.ECSTaskExecutionRole}}'
       TaskRoleArn: !Ref "AWS::NoValue"
       ContainerDefinitions:
-        - Name: '{{service_instance.unique_name}}'
+        - Name: '{{service_instance_name}}'
           Cpu: !FindInMap [TaskSize, {{service_instance.task_size}}, cpu]
           Memory: !FindInMap [TaskSize, {{service_instance.task_size}}, memory]
           Image: '{{service_instance.image}}'
@@ -67,9 +67,9 @@ Resources:
           LogConfiguration:
             LogDriver: 'awslogs'
             Options:
-              awslogs-group: '{{service_instance.unique_name}}'
+              awslogs-group: '{{service_name}}/{{service_instance_name}}'
               awslogs-region: !Ref 'AWS::Region'
-              awslogs-stream-prefix: '{{service_instance.unique_name}}'
+              awslogs-stream-prefix: '{{service_name}}/{{service_instance_name}}'
       Tags: 
         - Key: Name 
           Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
@@ -81,7 +81,7 @@ Resources:
     Type: AWS::ECS::Service
     DependsOn: LoadBalancerRule
     Properties:
-      ServiceName: '{{service_instance.unique_name}}'
+      ServiceName: '{{service_name}}_{{service_instance_name}}'
       Cluster: '{{environment.ClusterName}}'
       LaunchType: FARGATE
       DeploymentConfiguration:
@@ -101,7 +101,7 @@ Resources:
       - RegistryArn: !GetAtt DiscoveryService.Arn
         Port: 80
       LoadBalancers:
-        - ContainerName: '{{service_instance.unique_name}}'
+        - ContainerName: '{{service_instance_name}}'
           ContainerPort: '{{service_instance.port}}'
           TargetGroupArn: !Ref 'TargetGroup'
       Tags: 
@@ -122,7 +122,11 @@ Resources:
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
       TargetType: ip
-      Name: '{{service_instance.unique_name}}'
+      # Note that the Name property has a 32 character limit, which could be
+      # reached by using either {{service_name}}, {{service_instance_name}}
+      # or a combination of both as we're doing here, so we truncate the name to 29 characters
+      # plus an ellipsis different from '...' or '---' to avoid running into errors.
+      Name: '{{(service_name~"--"~service_instance_name)|truncate(29, true, 'zzz')}}'      
       Port: '{{service_instance.port}}'
       Protocol: HTTP
       UnhealthyThresholdCount: 2
@@ -157,7 +161,7 @@ Resources:
           - '/'
           - - service
             - '{{environment.ClusterName}}'
-            - '{{service_instance.unique_name}}'
+            - '{{service_name}}_{{service_instance_name}}'
       MinCapacity: 1
       MaxCapacity: 10
       RoleARN: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService
@@ -171,7 +175,7 @@ Resources:
         Fn::Join:
           - '/'
           - - scale
-            - '{{service_instance.unique_name}}'
+            - '{{service_name}}_{{service_instance_name}}'
             - down
       PolicyType: StepScaling
       ResourceId:
@@ -179,7 +183,7 @@ Resources:
           - '/'
           - - service
             - '{{environment.ClusterName}}'
-            - '{{service_instance.unique_name}}'
+            - '{{service_name}}_{{service_instance_name}}'
       ScalableDimension: 'ecs:service:DesiredCount'
       ServiceNamespace: 'ecs'
       StepScalingPolicyConfiguration:
@@ -198,7 +202,7 @@ Resources:
         Fn::Join:
           - '/'
           - - scale
-            - '{{service_instance.unique_name}}'
+            - '{{service_name}}_{{service_instance_name}}'
             - up
       PolicyType: StepScaling
       ResourceId:
@@ -206,7 +210,7 @@ Resources:
           - '/'
           - - service
             - '{{environment.ClusterName}}'
-            - '{{service_instance.unique_name}}'
+            - '{{service_name}}_{{service_instance_name}}'
       ScalableDimension: 'ecs:service:DesiredCount'
       ServiceNamespace: 'ecs'
       StepScalingPolicyConfiguration:
@@ -231,17 +235,17 @@ Resources:
         Fn::Join:
           - '-'
           - - low-cpu
-            - '{{service_instance.unique_name}}'
+            - '{{service_name}}_{{service_instance_name}}'
       AlarmDescription:
         Fn::Join:
           - ' '
           - - "Low CPU utilization for service"
-            - '{{service_instance.unique_name}}'
+            - '{{service_name}}_{{service_instance_name}}'
       MetricName: CPUUtilization
       Namespace: AWS/ECS
       Dimensions:
         - Name: ServiceName
-          Value: '{{service_instance.unique_name}}'
+          Value: '{{service_name}}_{{service_instance_name}}'
         - Name: ClusterName
           Value:
             '{{environment.ClusterName}}'
@@ -260,17 +264,17 @@ Resources:
         Fn::Join:
           - '-'
           - - high-cpu
-            - '{{service_instance.unique_name}}'
+            - '{{service_name}}_{{service_instance_name}}'
       AlarmDescription:
         Fn::Join:
           - ' '
           - - "High CPU utilization for service"
-            - '{{service_instance.unique_name}}'
+            - '{{service_name}}_{{service_instance_name}}'
       MetricName: CPUUtilization
       Namespace: AWS/ECS
       Dimensions:
         - Name: ServiceName
-          Value: '{{service_instance.unique_name}}'
+          Value: '{{service_name}}_{{service_instance_name}}'
         - Name: ClusterName
           Value:
             '{{environment.ClusterName}}'

--- a/public-private-fargate-microservices/service/loadbalanced-public-svc/infrastructure/manifest.yaml
+++ b/public-private-fargate-microservices/service/loadbalanced-public-svc/infrastructure/manifest.yaml
@@ -1,0 +1,5 @@
+infrastructure:
+  templates:
+    - file: "cloudformation.yaml"
+      engine: jinja
+      template_language: cloudformation

--- a/public-private-fargate-microservices/service/loadbalanced-public-svc/pipeline/cloudformation.yaml
+++ b/public-private-fargate-microservices/service/loadbalanced-public-svc/pipeline/cloudformation.yaml
@@ -1,0 +1,708 @@
+Resources:
+  ECRRepo:
+    Type: AWS::ECR::Repository
+    DeletionPolicy: Retain
+  BuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        PrivilegedMode: true
+        Type: LINUX_CONTAINER
+        EnvironmentVariables:
+        - Name: repo_name
+          Type: PLAINTEXT
+          Value: !Ref ECRRepo
+        - Name: service_name
+          Type: PLAINTEXT
+          Value: '{{service_name}}'
+      ServiceRole:
+        Fn::GetAtt:
+          - PublishRole
+          - Arn
+      Source:
+        BuildSpec:
+          Fn::Join:
+            - ""
+            - - >-
+                {
+                  "version": "0.2",
+                  "phases": {
+                    "install": {
+                      "runtime-versions": {
+                        "docker": 18
+                      },
+                      "commands": [
+                        "aws s3 cp s3://aws-proton-preview-public-files/model/proton-2020-07-20.normal.json .",
+                        "aws s3 cp s3://aws-proton-preview-public-files/model/waiters2.json .",
+                        "aws configure add-model --service-model file://proton-2020-07-20.normal.json --service-name proton-preview",
+                        "mv waiters2.json ~/.aws/models/proton-preview/2020-07-20/waiters-2.json",
+                        "echo 'f6bd1536a743ab170b35c94ed4c7c4479763356bd543af5d391122f4af852460  yq_linux_amd64' > yq_linux_amd64.sha",
+                        "wget https://github.com/mikefarah/yq/releases/download/3.4.0/yq_linux_amd64",
+                        "sha256sum -c yq_linux_amd64.sha",
+                        "mv yq_linux_amd64 /usr/bin/yq",
+                        "chmod +x /usr/bin/yq"
+                      ]
+                    },
+                    "pre_build": {
+                      "commands": [
+                        "cd $CODEBUILD_SRC_DIR",
+                        "$(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)",
+                        "{{ pipeline.unit_test_command }}",
+                      ]
+                    },
+                    "build": {
+                      "commands": [
+                        "IMAGE_REPO_NAME=$repo_name",
+                        "IMAGE_TAG=$CODEBUILD_BUILD_NUMBER",
+                        "IMAGE_ID=
+              - Ref: AWS::AccountId
+              - >-
+                .dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG",
+                        "docker build -t $IMAGE_REPO_NAME:$IMAGE_TAG -f {{ pipeline.dockerfile }} .",
+                        "docker tag $IMAGE_REPO_NAME:$IMAGE_TAG $IMAGE_ID;",
+                        "docker push $IMAGE_ID"
+                      ]
+                    },
+                    "post_build": {
+                      "commands": [
+                        "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION get-service --service-name $service_name | jq -r .service.spec > service.yaml",
+                        "yq w service.yaml 'instances[*].spec.image' \"$IMAGE_ID\" > rendered_service.yaml"
+                      ]
+                    }
+                  },
+                  "artifacts": {
+                    "files": [
+                      "rendered_service.yaml"
+                    ]
+                  }
+                }
+        Type: CODEPIPELINE
+      EncryptionKey:
+        Fn::GetAtt:
+          - PipelineArtifactsBucketEncryptionKey
+          - Arn
+{% for service_instance in service_instances %}
+  Deploy{{loop.index}}Project:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        PrivilegedMode: false
+        Type: LINUX_CONTAINER
+        EnvironmentVariables:
+        - Name: service_name
+          Type: PLAINTEXT
+          Value:  '{{service_name}}'
+        - Name: service_instance_name
+          Type: PLAINTEXT
+          Value: '{{service_instance.name}}'
+      ServiceRole:
+        Fn::GetAtt:
+          - DeploymentRole
+          - Arn
+      Source:
+        BuildSpec: >-
+          {
+            "version": "0.2",
+            "phases": {
+              "install": {
+                "commands": [
+                  "aws s3 cp s3://aws-proton-preview-public-files/model/proton-2020-07-20.normal.json .",
+                  "aws s3 cp s3://aws-proton-preview-public-files/model/waiters2.json .",
+                  "aws configure add-model --service-model file://proton-2020-07-20.normal.json --service-name proton-preview",
+                  "mv waiters2.json ~/.aws/models/proton-preview/2020-07-20/waiters-2.json"
+                ]
+              },
+              "build": {
+                "commands": [
+                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --version-update-type UPDATE_SPEC --service-instance-name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
+                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --service-instance-name $service_instance_name --service-name $service_name"
+                ]
+              }
+            }
+          }
+        Type: CODEPIPELINE
+      EncryptionKey:
+        Fn::GetAtt:
+          - PipelineArtifactsBucketEncryptionKey
+          - Arn
+{% endfor %}
+  # This role is used to build and publish an image to ECR
+  PublishRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+        Version: "2012-10-17"
+  PublishRoleDefaultPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Effect: Allow
+            Resource:
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":logs:"
+                    - Ref: AWS::Region
+                    - ":"
+                    - Ref: AWS::AccountId
+                    - :log-group:/aws/codebuild/
+                    - Ref: BuildProject
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":logs:"
+                    - Ref: AWS::Region
+                    - ":"
+                    - Ref: AWS::AccountId
+                    - :log-group:/aws/codebuild/
+                    - Ref: BuildProject
+                    - :*
+          - Action:
+              - codebuild:CreateReportGroup
+              - codebuild:CreateReport
+              - codebuild:UpdateReport
+              - codebuild:BatchPutTestCases
+            Effect: Allow
+            Resource:
+              Fn::Join:
+                - ""
+                - - "arn:"
+                  - Ref: AWS::Partition
+                  - ":codebuild:"
+                  - Ref: AWS::Region
+                  - ":"
+                  - Ref: AWS::AccountId
+                  - :report-group/
+                  - Ref: BuildProject
+                  - -*
+          - Action:
+              - ecr:GetAuthorizationToken
+            Effect: Allow
+            Resource: "*"
+          - Action:
+              - ecr:BatchCheckLayerAvailability
+              - ecr:CompleteLayerUpload
+              - ecr:GetAuthorizationToken
+              - ecr:InitiateLayerUpload
+              - ecr:PutImage
+              - ecr:UploadLayerPart
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - ECRRepo
+                - Arn
+          - Action:
+              - proton:GetService
+            Effect: Allow
+            Resource: "*"
+          - Action: s3:GetObject
+            Effect: Allow
+            Resource:
+              - "arn:aws:s3:::aws-proton-preview-public-files/*"
+          - Action:
+              - s3:GetObject*
+              - s3:GetBucket*
+              - s3:List*
+              - s3:DeleteObject*
+              - s3:PutObject*
+              - s3:Abort*
+            Effect: Allow
+            Resource:
+              - Fn::GetAtt:
+                  - PipelineArtifactsBucket
+                  - Arn
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - PipelineArtifactsBucket
+                        - Arn
+                    - /*
+          - Action:
+              - kms:Decrypt
+              - kms:DescribeKey
+              - kms:Encrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - PipelineArtifactsBucketEncryptionKey
+                - Arn
+          - Action:
+              - kms:Decrypt
+              - kms:Encrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - PipelineArtifactsBucketEncryptionKey
+                - Arn
+        Version: "2012-10-17"
+      PolicyName: PublishRoleDefaultPolicy
+      Roles:
+        - Ref: PublishRole
+
+  DeploymentRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+        Version: "2012-10-17"
+  DeploymentRoleDefaultPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Effect: Allow
+            Resource:
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":logs:"
+                    - Ref: AWS::Region
+                    - ":"
+                    - Ref: AWS::AccountId
+                    - :log-group:/aws/codebuild/Deploy*Project*
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":logs:"
+                    - Ref: AWS::Region
+                    - ":"
+                    - Ref: AWS::AccountId
+                    - :log-group:/aws/codebuild/Deploy*Project:*
+          - Action:
+              - codebuild:CreateReportGroup
+              - codebuild:CreateReport
+              - codebuild:UpdateReport
+              - codebuild:BatchPutTestCases
+            Effect: Allow
+            Resource:
+              Fn::Join:
+                - ""
+                - - "arn:"
+                  - Ref: AWS::Partition
+                  - ":codebuild:"
+                  - Ref: AWS::Region
+                  - ":"
+                  - Ref: AWS::AccountId
+                  - :report-group/Deploy*Project
+                  - -*
+          - Action:
+              - proton:UpdateServiceInstance
+              - proton:GetServiceInstance
+            Effect: Allow
+            Resource: "*"
+          - Action: s3:GetObject
+            Effect: Allow
+            Resource:
+              - "arn:aws:s3:::aws-proton-preview-public-files/*"
+          - Action:
+              - s3:GetObject*
+              - s3:GetBucket*
+              - s3:List*
+            Effect: Allow
+            Resource:
+              - Fn::GetAtt:
+                  - PipelineArtifactsBucket
+                  - Arn
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - PipelineArtifactsBucket
+                        - Arn
+                    - /*
+          - Action:
+              - kms:Decrypt
+              - kms:DescribeKey
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - PipelineArtifactsBucketEncryptionKey
+                - Arn
+          - Action:
+              - kms:Decrypt
+              - kms:Encrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - PipelineArtifactsBucketEncryptionKey
+                - Arn
+        Version: "2012-10-17"
+      PolicyName: DeploymentRoleDefaultPolicy
+      Roles:
+        - Ref: DeploymentRole
+  PipelineArtifactsBucketEncryptionKey:
+    Type: AWS::KMS::Key
+    Properties:
+      KeyPolicy:
+        Statement:
+          - Action:
+              - kms:Create*
+              - kms:Describe*
+              - kms:Enable*
+              - kms:List*
+              - kms:Put*
+              - kms:Update*
+              - kms:Revoke*
+              - kms:Disable*
+              - kms:Get*
+              - kms:Delete*
+              - kms:ScheduleKeyDeletion
+              - kms:CancelKeyDeletion
+              - kms:GenerateDataKey
+              - kms:TagResource
+              - kms:UntagResource
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":iam::"
+                    - Ref: AWS::AccountId
+                    - :root
+            Resource: "*"
+          - Action:
+              - kms:Decrypt
+              - kms:DescribeKey
+              - kms:Encrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::GetAtt:
+                  - PipelineRole
+                  - Arn
+            Resource: "*"
+          - Action:
+              - kms:Decrypt
+              - kms:DescribeKey
+              - kms:Encrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::GetAtt:
+                  - PublishRole
+                  - Arn
+            Resource: "*"
+          - Action:
+              - kms:Decrypt
+              - kms:Encrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::GetAtt:
+                  - PublishRole
+                  - Arn
+            Resource: "*"
+          - Action:
+              - kms:Decrypt
+              - kms:DescribeKey
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::GetAtt:
+                  - DeploymentRole
+                  - Arn
+            Resource: "*"
+          - Action:
+              - kms:Decrypt
+              - kms:Encrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::GetAtt:
+                  - DeploymentRole
+                  - Arn
+            Resource: "*"
+        Version: "2012-10-17"
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+  PipelineArtifactsBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              KMSMasterKeyID:
+                Fn::GetAtt:
+                  - PipelineArtifactsBucketEncryptionKey
+                  - Arn
+              SSEAlgorithm: aws:kms
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
+  PipelineArtifactsBucketEncryptionKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: 'alias/codepipeline-encryption-key-{{ service_name }}'
+      TargetKeyId:
+        Fn::GetAtt:
+          - PipelineArtifactsBucketEncryptionKey
+          - Arn
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+  PipelineRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: codepipeline.amazonaws.com
+        Version: "2012-10-17"
+  PipelineRoleDefaultPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - s3:GetObject*
+              - s3:GetBucket*
+              - s3:List*
+              - s3:DeleteObject*
+              - s3:PutObject*
+              - s3:Abort*
+            Effect: Allow
+            Resource:
+              - Fn::GetAtt:
+                  - PipelineArtifactsBucket
+                  - Arn
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - PipelineArtifactsBucket
+                        - Arn
+                    - /*
+          - Action:
+              - kms:Decrypt
+              - kms:DescribeKey
+              - kms:Encrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - PipelineArtifactsBucketEncryptionKey
+                - Arn
+          - Action: codestar-connections:*
+            Effect: Allow
+            Resource: "*"
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - PipelineBuildCodePipelineActionRole
+                - Arn
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - PipelineDeployCodePipelineActionRole
+                - Arn
+        Version: "2012-10-17"
+      PolicyName: PipelineRoleDefaultPolicy
+      Roles:
+        - Ref: PipelineRole
+  Pipeline:
+    Type: AWS::CodePipeline::Pipeline
+    Properties:
+      RoleArn:
+        Fn::GetAtt:
+          - PipelineRole
+          - Arn
+      Stages:
+        - Actions:
+            - ActionTypeId:
+                Category: Source
+                Owner: AWS
+                Provider: CodeStarSourceConnection
+                Version: "1"
+              Configuration:
+                ConnectionArn: '{{ source.connection_arn }}'
+                FullRepositoryId: '{{ source.repository }}'
+                BranchName: '{{ source.branch }}'
+              Name: Checkout
+              OutputArtifacts:
+                - Name: Artifact_Source_Checkout
+              RunOrder: 1
+          Name: Source
+        - Actions:
+            - ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Provider: CodeBuild
+                Version: "1"
+              Configuration:
+                ProjectName:
+                  Ref: BuildProject
+              InputArtifacts:
+                - Name: Artifact_Source_Checkout
+              Name: Build
+              OutputArtifacts:
+                - Name: BuildOutput
+              RoleArn:
+                Fn::GetAtt:
+                  - PipelineBuildCodePipelineActionRole
+                  - Arn
+              RunOrder: 1
+          Name: Build {%- for service_instance in service_instances %}
+        - Actions:
+            - ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Provider: CodeBuild
+                Version: "1"
+              Configuration:
+                ProjectName:
+                  Ref: Deploy{{loop.index}}Project
+              InputArtifacts:
+                - Name: BuildOutput
+              Name: Deploy
+              RoleArn:
+                Fn::GetAtt:
+                  - PipelineDeployCodePipelineActionRole
+                  - Arn
+              RunOrder: 1
+          Name: 'Deploy{{service_instance.name}}'
+{%- endfor %}
+      ArtifactStore:
+        EncryptionKey:
+          Id:
+            Fn::GetAtt:
+              - PipelineArtifactsBucketEncryptionKey
+              - Arn
+          Type: KMS
+        Location:
+          Ref: PipelineArtifactsBucket
+        Type: S3
+    DependsOn:
+      - PipelineRoleDefaultPolicy
+      - PipelineRole
+  PipelineBuildCodePipelineActionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":iam::"
+                    - Ref: AWS::AccountId
+                    - :root
+        Version: "2012-10-17"
+  PipelineBuildCodePipelineActionRoleDefaultPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - codebuild:BatchGetBuilds
+              - codebuild:StartBuild
+              - codebuild:StopBuild
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - BuildProject
+                - Arn
+        Version: "2012-10-17"
+      PolicyName: PipelineBuildCodePipelineActionRoleDefaultPolicy
+      Roles:
+        - Ref: PipelineBuildCodePipelineActionRole
+  PipelineDeployCodePipelineActionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":iam::"
+                    - Ref: AWS::AccountId
+                    - :root
+        Version: "2012-10-17"
+  PipelineDeployCodePipelineActionRoleDefaultPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - codebuild:BatchGetBuilds
+              - codebuild:StartBuild
+              - codebuild:StopBuild
+            Effect: Allow
+            Resource:
+              Fn::Join:
+                - ""
+                - - "arn:"
+                  - Ref: AWS::Partition
+                  - ":codebuild:"
+                  - Ref: AWS::Region
+                  - ":"
+                  - Ref: AWS::AccountId
+                  - ":project/Deploy*"
+        Version: "2012-10-17"
+      PolicyName: PipelineDeployCodePipelineActionRoleDefaultPolicy
+      Roles:
+        - Ref: PipelineDeployCodePipelineActionRole
+Outputs:
+  PipelineEndpoint:
+    Description: The URL to access the pipeline
+    Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/codesuite/codepipeline/pipelines/${Pipeline}/view?region=${AWS::Region}"

--- a/public-private-fargate-microservices/service/loadbalanced-public-svc/pipeline/manifest.yaml
+++ b/public-private-fargate-microservices/service/loadbalanced-public-svc/pipeline/manifest.yaml
@@ -1,0 +1,5 @@
+infrastructure:
+  templates:
+    - file: "cloudformation.yaml"
+      engine: jinja
+      template_language: cloudformation

--- a/public-private-fargate-microservices/service/loadbalanced-public-svc/schema/schema.yaml
+++ b/public-private-fargate-microservices/service/loadbalanced-public-svc/schema/schema.yaml
@@ -31,18 +31,12 @@ schema:
           default: "public.ecr.aws/z9d2n7e1/nginx:1.19.5"
           minLength: 1
           maxLength: 200
-        unique_name:
-          type: string
-          description: "The unique name of your service identifier. This will be used to name your log group, task definition and ECS service"
-          minLength: 1
-          maxLength: 100
         service_discovery_name:
           type: string
           description: "The name of the service to register in service discovery"
           minLength: 3
           maxLength: 24
       required:
-        - unique_name
         - service_discovery_name
 
     PipelineInputs:

--- a/public-private-fargate-microservices/service/loadbalanced-public-svc/schema/schema.yaml
+++ b/public-private-fargate-microservices/service/loadbalanced-public-svc/schema/schema.yaml
@@ -1,0 +1,63 @@
+schema:
+  format:
+    openapi: "3.0.0"
+  service_input_type: "LoadBalancedServiceInput"
+  pipeline_input_type: "PipelineInputs"
+
+  types:
+    LoadBalancedServiceInput:
+      type: object
+      description: "Input properties for a loadbalanced Fargate service"
+      properties:
+        port:
+          type: number
+          description: "The port to route traffic to"
+          default: 80
+          minimum: 0
+          maximum: 65535
+        desired_count:
+          type: number
+          description: "The default number of Fargate tasks you want running"
+          default: 1
+          minimum: 1
+        task_size:
+          type: string
+          description: "The size of the task you want to run"
+          enum: ["x-small", "small", "medium", "large", "x-large"]
+          default: "x-small"
+        image:
+          type: string
+          description: "The name/url of the container image"
+          default: "public.ecr.aws/z9d2n7e1/nginx:1.19.5"
+          minLength: 1
+          maxLength: 200
+        unique_name:
+          type: string
+          description: "The unique name of your service identifier. This will be used to name your log group, task definition and ECS service"
+          minLength: 1
+          maxLength: 100
+        service_discovery_name:
+          type: string
+          description: "The name of the service to register in service discovery"
+          minLength: 3
+          maxLength: 24
+      required:
+        - unique_name
+        - service_discovery_name
+
+    PipelineInputs:
+      type: object
+      description: "Pipeline input properties"
+      properties:
+        dockerfile:
+          type: string
+          description: "The location of the Dockerfile to build"
+          default: "Dockerfile"
+          minLength: 1
+          maxLength: 100
+        unit_test_command:
+          type: string
+          description: "The command to run to unit test the application code"
+          default: "echo 'add your unit test command here'"
+          minLength: 1
+          maxLength: 200

--- a/public-private-fargate-microservices/service/private-fargate-svc/infrastructure/cloudformation.yaml
+++ b/public-private-fargate-microservices/service/private-fargate-svc/infrastructure/cloudformation.yaml
@@ -41,14 +41,14 @@ Resources:
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: '{{service_instance.unique_name}}'
+      LogGroupName: '{{service_name}}/{{service_instance_name}}'
 
   # The task definition. This is a simple metadata description of what
   # container to run, and what resource requirements it has.
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:
-      Family: '{{service_instance.unique_name}}'
+      Family: '{{service_name}}_{{service_instance_name}}'
       Cpu: !FindInMap [TaskSize, {{service_instance.task_size}}, cpu]
       Memory: !FindInMap [TaskSize, {{service_instance.task_size}}, memory]
       NetworkMode: awsvpc
@@ -57,7 +57,7 @@ Resources:
       ExecutionRoleArn: '{{environment.ECSTaskExecutionRole}}'
       TaskRoleArn: !Ref "AWS::NoValue"
       ContainerDefinitions:
-        - Name: '{{service_instance.unique_name}}'
+        - Name: '{{service_instance_name}}'
           Cpu: !FindInMap [TaskSize, {{service_instance.task_size}}, cpu]
           Memory: !FindInMap [TaskSize, {{service_instance.task_size}}, memory]
           Image: '{{service_instance.image}}'
@@ -66,9 +66,9 @@ Resources:
           LogConfiguration:
             LogDriver: 'awslogs'
             Options:
-              awslogs-group: '{{service_instance.unique_name}}'
+              awslogs-group: '{{service_name}}/{{service_instance_name}}'
               awslogs-region: !Ref 'AWS::Region'
-              awslogs-stream-prefix: '{{service_instance.unique_name}}'
+              awslogs-stream-prefix: '{{service_name}}/{{service_instance_name}}'
       Tags: 
         - Key: Name 
           Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
@@ -79,7 +79,7 @@ Resources:
   Service:
     Type: AWS::ECS::Service
     Properties:
-      ServiceName: '{{service_instance.unique_name}}'
+      ServiceName: '{{service_name}}_{{service_instance_name}}'
       Cluster: '{{environment.ClusterName}}'
       LaunchType: FARGATE
       DesiredCount: '{{service_instance.desired_count}}'

--- a/public-private-fargate-microservices/service/private-fargate-svc/infrastructure/cloudformation.yaml
+++ b/public-private-fargate-microservices/service/private-fargate-svc/infrastructure/cloudformation.yaml
@@ -1,0 +1,105 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Deploy a backend service on AWS Fargate, hosted in a private subnet, and accessible via Service Discovery.
+Mappings:
+  EnvironmentNameConfig:
+    Environment: 
+      Name: '{{ environment.environment_name_tag}}'
+  TaskSize:
+    x-small:
+      cpu: 256
+      memory: 512
+    small:
+      cpu: 512
+      memory: 1024
+    medium:
+      cpu: 1024
+      memory: 2048
+    large:
+      cpu: 2048
+      memory: 4096
+    x-large:
+      cpu: 4096
+      memory: 8192
+Resources:
+  # Register service in ServiceDiscovery Service
+  DiscoveryService:
+    Type: AWS::ServiceDiscovery::Service
+    Properties:
+      Description: Discovery Service for the Demo Application
+      DnsConfig:
+        RoutingPolicy: MULTIVALUE
+        DnsRecords:
+          - TTL: 60
+            Type: A
+          - TTL: 60
+            Type: SRV
+      HealthCheckCustomConfig:
+        FailureThreshold: 1
+      Name: '{{service_instance.service_discovery_name}}'
+      NamespaceId: '{{environment.PrivateNamespace}}'
+  # A log group for storing the stdout logs from this service's containers
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: '{{service_instance.unique_name}}'
+
+  # The task definition. This is a simple metadata description of what
+  # container to run, and what resource requirements it has.
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: '{{service_instance.unique_name}}'
+      Cpu: !FindInMap [TaskSize, {{service_instance.task_size}}, cpu]
+      Memory: !FindInMap [TaskSize, {{service_instance.task_size}}, memory]
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      ExecutionRoleArn: '{{environment.ECSTaskExecutionRole}}'
+      TaskRoleArn: !Ref "AWS::NoValue"
+      ContainerDefinitions:
+        - Name: '{{service_instance.unique_name}}'
+          Cpu: !FindInMap [TaskSize, {{service_instance.task_size}}, cpu]
+          Memory: !FindInMap [TaskSize, {{service_instance.task_size}}, memory]
+          Image: '{{service_instance.image}}'
+          PortMappings:
+            - ContainerPort: '{{service_instance.port}}'
+          LogConfiguration:
+            LogDriver: 'awslogs'
+            Options:
+              awslogs-group: '{{service_instance.unique_name}}'
+              awslogs-region: !Ref 'AWS::Region'
+              awslogs-stream-prefix: '{{service_instance.unique_name}}'
+      Tags: 
+        - Key: Name 
+          Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
+
+  # The service_instance. The service is a resource which allows you to run multiple
+  # copies of a type of task, and gather up their logs and metrics, as well
+  # as monitor the number of running tasks and replace any that have crashed
+  Service:
+    Type: AWS::ECS::Service
+    Properties:
+      ServiceName: '{{service_instance.unique_name}}'
+      Cluster: '{{environment.ClusterName}}'
+      LaunchType: FARGATE
+      DesiredCount: '{{service_instance.desired_count}}'
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED
+          SecurityGroups:
+            - '{{environment.ContainerSecurityGroup}}'
+          Subnets:
+            - '{{environment.PrivateSubnetOne}}'
+            - '{{environment.PrivateSubnetTwo}}'
+      TaskDefinition: !Ref 'TaskDefinition'
+      ServiceRegistries:
+      - RegistryArn: !GetAtt DiscoveryService.Arn
+        Port: 8080
+      Tags: 
+        - Key: Name 
+          Value: !FindInMap ['EnvironmentNameConfig', 'Environment', 'Name']
+
+Outputs:
+  ServiceDiscovery:
+    Description: The registered service discovery Service Id
+    Value: !Ref DiscoveryService

--- a/public-private-fargate-microservices/service/private-fargate-svc/infrastructure/manifest.yaml
+++ b/public-private-fargate-microservices/service/private-fargate-svc/infrastructure/manifest.yaml
@@ -1,0 +1,5 @@
+infrastructure:
+  templates:
+    - file: "cloudformation.yaml"
+      engine: jinja
+      template_language: cloudformation

--- a/public-private-fargate-microservices/service/private-fargate-svc/pipeline/cloudformation.yaml
+++ b/public-private-fargate-microservices/service/private-fargate-svc/pipeline/cloudformation.yaml
@@ -1,0 +1,708 @@
+Resources:
+  ECRRepo:
+    Type: AWS::ECR::Repository
+    DeletionPolicy: Retain
+  BuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        PrivilegedMode: true
+        Type: LINUX_CONTAINER
+        EnvironmentVariables:
+        - Name: repo_name
+          Type: PLAINTEXT
+          Value: !Ref ECRRepo
+        - Name: service_name
+          Type: PLAINTEXT
+          Value: '{{service_name}}'
+      ServiceRole:
+        Fn::GetAtt:
+          - PublishRole
+          - Arn
+      Source:
+        BuildSpec:
+          Fn::Join:
+            - ""
+            - - >-
+                {
+                  "version": "0.2",
+                  "phases": {
+                    "install": {
+                      "runtime-versions": {
+                        "docker": 18
+                      },
+                      "commands": [
+                        "aws s3 cp s3://aws-proton-preview-public-files/model/proton-2020-07-20.normal.json .",
+                        "aws s3 cp s3://aws-proton-preview-public-files/model/waiters2.json .",
+                        "aws configure add-model --service-model file://proton-2020-07-20.normal.json --service-name proton-preview",
+                        "mv waiters2.json ~/.aws/models/proton-preview/2020-07-20/waiters-2.json",
+                        "echo 'f6bd1536a743ab170b35c94ed4c7c4479763356bd543af5d391122f4af852460  yq_linux_amd64' > yq_linux_amd64.sha",
+                        "wget https://github.com/mikefarah/yq/releases/download/3.4.0/yq_linux_amd64",
+                        "sha256sum -c yq_linux_amd64.sha",
+                        "mv yq_linux_amd64 /usr/bin/yq",
+                        "chmod +x /usr/bin/yq"
+                      ]
+                    },
+                    "pre_build": {
+                      "commands": [
+                        "cd $CODEBUILD_SRC_DIR",
+                        "$(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)",
+                        "{{ pipeline.unit_test_command }}",
+                      ]
+                    },
+                    "build": {
+                      "commands": [
+                        "IMAGE_REPO_NAME=$repo_name",
+                        "IMAGE_TAG=$CODEBUILD_BUILD_NUMBER",
+                        "IMAGE_ID=
+              - Ref: AWS::AccountId
+              - >-
+                .dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG",
+                        "docker build -t $IMAGE_REPO_NAME:$IMAGE_TAG -f {{ pipeline.dockerfile }} .",
+                        "docker tag $IMAGE_REPO_NAME:$IMAGE_TAG $IMAGE_ID;",
+                        "docker push $IMAGE_ID"
+                      ]
+                    },
+                    "post_build": {
+                      "commands": [
+                        "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION get-service --service-name $service_name | jq -r .service.spec > service.yaml",
+                        "yq w service.yaml 'instances[*].spec.image' \"$IMAGE_ID\" > rendered_service.yaml"
+                      ]
+                    }
+                  },
+                  "artifacts": {
+                    "files": [
+                      "rendered_service.yaml"
+                    ]
+                  }
+                }
+        Type: CODEPIPELINE
+      EncryptionKey:
+        Fn::GetAtt:
+          - PipelineArtifactsBucketEncryptionKey
+          - Arn
+{% for service_instance in service_instances %}
+  Deploy{{loop.index}}Project:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        PrivilegedMode: false
+        Type: LINUX_CONTAINER
+        EnvironmentVariables:
+        - Name: service_name
+          Type: PLAINTEXT
+          Value:  '{{service_name}}'
+        - Name: service_instance_name
+          Type: PLAINTEXT
+          Value: '{{service_instance.name}}'
+      ServiceRole:
+        Fn::GetAtt:
+          - DeploymentRole
+          - Arn
+      Source:
+        BuildSpec: >-
+          {
+            "version": "0.2",
+            "phases": {
+              "install": {
+                "commands": [
+                  "aws s3 cp s3://aws-proton-preview-public-files/model/proton-2020-07-20.normal.json .",
+                  "aws s3 cp s3://aws-proton-preview-public-files/model/waiters2.json .",
+                  "aws configure add-model --service-model file://proton-2020-07-20.normal.json --service-name proton-preview",
+                  "mv waiters2.json ~/.aws/models/proton-preview/2020-07-20/waiters-2.json"
+                ]
+              },
+              "build": {
+                "commands": [
+                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --version-update-type UPDATE_SPEC --service-instance-name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
+                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --service-instance-name $service_instance_name --service-name $service_name"
+                ]
+              }
+            }
+          }
+        Type: CODEPIPELINE
+      EncryptionKey:
+        Fn::GetAtt:
+          - PipelineArtifactsBucketEncryptionKey
+          - Arn
+{% endfor %}
+  # This role is used to build and publish an image to ECR
+  PublishRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+        Version: "2012-10-17"
+  PublishRoleDefaultPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Effect: Allow
+            Resource:
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":logs:"
+                    - Ref: AWS::Region
+                    - ":"
+                    - Ref: AWS::AccountId
+                    - :log-group:/aws/codebuild/
+                    - Ref: BuildProject
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":logs:"
+                    - Ref: AWS::Region
+                    - ":"
+                    - Ref: AWS::AccountId
+                    - :log-group:/aws/codebuild/
+                    - Ref: BuildProject
+                    - :*
+          - Action:
+              - codebuild:CreateReportGroup
+              - codebuild:CreateReport
+              - codebuild:UpdateReport
+              - codebuild:BatchPutTestCases
+            Effect: Allow
+            Resource:
+              Fn::Join:
+                - ""
+                - - "arn:"
+                  - Ref: AWS::Partition
+                  - ":codebuild:"
+                  - Ref: AWS::Region
+                  - ":"
+                  - Ref: AWS::AccountId
+                  - :report-group/
+                  - Ref: BuildProject
+                  - -*
+          - Action:
+              - ecr:GetAuthorizationToken
+            Effect: Allow
+            Resource: "*"
+          - Action:
+              - ecr:BatchCheckLayerAvailability
+              - ecr:CompleteLayerUpload
+              - ecr:GetAuthorizationToken
+              - ecr:InitiateLayerUpload
+              - ecr:PutImage
+              - ecr:UploadLayerPart
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - ECRRepo
+                - Arn
+          - Action:
+              - proton:GetService
+            Effect: Allow
+            Resource: "*"
+          - Action: s3:GetObject
+            Effect: Allow
+            Resource:
+              - "arn:aws:s3:::aws-proton-preview-public-files/*"
+          - Action:
+              - s3:GetObject*
+              - s3:GetBucket*
+              - s3:List*
+              - s3:DeleteObject*
+              - s3:PutObject*
+              - s3:Abort*
+            Effect: Allow
+            Resource:
+              - Fn::GetAtt:
+                  - PipelineArtifactsBucket
+                  - Arn
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - PipelineArtifactsBucket
+                        - Arn
+                    - /*
+          - Action:
+              - kms:Decrypt
+              - kms:DescribeKey
+              - kms:Encrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - PipelineArtifactsBucketEncryptionKey
+                - Arn
+          - Action:
+              - kms:Decrypt
+              - kms:Encrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - PipelineArtifactsBucketEncryptionKey
+                - Arn
+        Version: "2012-10-17"
+      PolicyName: PublishRoleDefaultPolicy
+      Roles:
+        - Ref: PublishRole
+
+  DeploymentRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+        Version: "2012-10-17"
+  DeploymentRoleDefaultPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Effect: Allow
+            Resource:
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":logs:"
+                    - Ref: AWS::Region
+                    - ":"
+                    - Ref: AWS::AccountId
+                    - :log-group:/aws/codebuild/Deploy*Project*
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":logs:"
+                    - Ref: AWS::Region
+                    - ":"
+                    - Ref: AWS::AccountId
+                    - :log-group:/aws/codebuild/Deploy*Project:*
+          - Action:
+              - codebuild:CreateReportGroup
+              - codebuild:CreateReport
+              - codebuild:UpdateReport
+              - codebuild:BatchPutTestCases
+            Effect: Allow
+            Resource:
+              Fn::Join:
+                - ""
+                - - "arn:"
+                  - Ref: AWS::Partition
+                  - ":codebuild:"
+                  - Ref: AWS::Region
+                  - ":"
+                  - Ref: AWS::AccountId
+                  - :report-group/Deploy*Project
+                  - -*
+          - Action:
+              - proton:UpdateServiceInstance
+              - proton:GetServiceInstance
+            Effect: Allow
+            Resource: "*"
+          - Action: s3:GetObject
+            Effect: Allow
+            Resource:
+              - "arn:aws:s3:::aws-proton-preview-public-files/*"
+          - Action:
+              - s3:GetObject*
+              - s3:GetBucket*
+              - s3:List*
+            Effect: Allow
+            Resource:
+              - Fn::GetAtt:
+                  - PipelineArtifactsBucket
+                  - Arn
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - PipelineArtifactsBucket
+                        - Arn
+                    - /*
+          - Action:
+              - kms:Decrypt
+              - kms:DescribeKey
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - PipelineArtifactsBucketEncryptionKey
+                - Arn
+          - Action:
+              - kms:Decrypt
+              - kms:Encrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - PipelineArtifactsBucketEncryptionKey
+                - Arn
+        Version: "2012-10-17"
+      PolicyName: DeploymentRoleDefaultPolicy
+      Roles:
+        - Ref: DeploymentRole
+  PipelineArtifactsBucketEncryptionKey:
+    Type: AWS::KMS::Key
+    Properties:
+      KeyPolicy:
+        Statement:
+          - Action:
+              - kms:Create*
+              - kms:Describe*
+              - kms:Enable*
+              - kms:List*
+              - kms:Put*
+              - kms:Update*
+              - kms:Revoke*
+              - kms:Disable*
+              - kms:Get*
+              - kms:Delete*
+              - kms:ScheduleKeyDeletion
+              - kms:CancelKeyDeletion
+              - kms:GenerateDataKey
+              - kms:TagResource
+              - kms:UntagResource
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":iam::"
+                    - Ref: AWS::AccountId
+                    - :root
+            Resource: "*"
+          - Action:
+              - kms:Decrypt
+              - kms:DescribeKey
+              - kms:Encrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::GetAtt:
+                  - PipelineRole
+                  - Arn
+            Resource: "*"
+          - Action:
+              - kms:Decrypt
+              - kms:DescribeKey
+              - kms:Encrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::GetAtt:
+                  - PublishRole
+                  - Arn
+            Resource: "*"
+          - Action:
+              - kms:Decrypt
+              - kms:Encrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::GetAtt:
+                  - PublishRole
+                  - Arn
+            Resource: "*"
+          - Action:
+              - kms:Decrypt
+              - kms:DescribeKey
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::GetAtt:
+                  - DeploymentRole
+                  - Arn
+            Resource: "*"
+          - Action:
+              - kms:Decrypt
+              - kms:Encrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::GetAtt:
+                  - DeploymentRole
+                  - Arn
+            Resource: "*"
+        Version: "2012-10-17"
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+  PipelineArtifactsBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              KMSMasterKeyID:
+                Fn::GetAtt:
+                  - PipelineArtifactsBucketEncryptionKey
+                  - Arn
+              SSEAlgorithm: aws:kms
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
+  PipelineArtifactsBucketEncryptionKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: 'alias/codepipeline-encryption-key-{{ service_name }}'
+      TargetKeyId:
+        Fn::GetAtt:
+          - PipelineArtifactsBucketEncryptionKey
+          - Arn
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+  PipelineRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: codepipeline.amazonaws.com
+        Version: "2012-10-17"
+  PipelineRoleDefaultPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - s3:GetObject*
+              - s3:GetBucket*
+              - s3:List*
+              - s3:DeleteObject*
+              - s3:PutObject*
+              - s3:Abort*
+            Effect: Allow
+            Resource:
+              - Fn::GetAtt:
+                  - PipelineArtifactsBucket
+                  - Arn
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - PipelineArtifactsBucket
+                        - Arn
+                    - /*
+          - Action:
+              - kms:Decrypt
+              - kms:DescribeKey
+              - kms:Encrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - PipelineArtifactsBucketEncryptionKey
+                - Arn
+          - Action: codestar-connections:*
+            Effect: Allow
+            Resource: "*"
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - PipelineBuildCodePipelineActionRole
+                - Arn
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - PipelineDeployCodePipelineActionRole
+                - Arn
+        Version: "2012-10-17"
+      PolicyName: PipelineRoleDefaultPolicy
+      Roles:
+        - Ref: PipelineRole
+  Pipeline:
+    Type: AWS::CodePipeline::Pipeline
+    Properties:
+      RoleArn:
+        Fn::GetAtt:
+          - PipelineRole
+          - Arn
+      Stages:
+        - Actions:
+            - ActionTypeId:
+                Category: Source
+                Owner: AWS
+                Provider: CodeStarSourceConnection
+                Version: "1"
+              Configuration:
+                ConnectionArn: '{{ source.connection_arn }}'
+                FullRepositoryId: '{{ source.repository }}'
+                BranchName: '{{ source.branch }}'
+              Name: Checkout
+              OutputArtifacts:
+                - Name: Artifact_Source_Checkout
+              RunOrder: 1
+          Name: Source
+        - Actions:
+            - ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Provider: CodeBuild
+                Version: "1"
+              Configuration:
+                ProjectName:
+                  Ref: BuildProject
+              InputArtifacts:
+                - Name: Artifact_Source_Checkout
+              Name: Build
+              OutputArtifacts:
+                - Name: BuildOutput
+              RoleArn:
+                Fn::GetAtt:
+                  - PipelineBuildCodePipelineActionRole
+                  - Arn
+              RunOrder: 1
+          Name: Build {%- for service_instance in service_instances %}
+        - Actions:
+            - ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Provider: CodeBuild
+                Version: "1"
+              Configuration:
+                ProjectName:
+                  Ref: Deploy{{loop.index}}Project
+              InputArtifacts:
+                - Name: BuildOutput
+              Name: Deploy
+              RoleArn:
+                Fn::GetAtt:
+                  - PipelineDeployCodePipelineActionRole
+                  - Arn
+              RunOrder: 1
+          Name: 'Deploy{{service_instance.name}}'
+{%- endfor %}
+      ArtifactStore:
+        EncryptionKey:
+          Id:
+            Fn::GetAtt:
+              - PipelineArtifactsBucketEncryptionKey
+              - Arn
+          Type: KMS
+        Location:
+          Ref: PipelineArtifactsBucket
+        Type: S3
+    DependsOn:
+      - PipelineRoleDefaultPolicy
+      - PipelineRole
+  PipelineBuildCodePipelineActionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":iam::"
+                    - Ref: AWS::AccountId
+                    - :root
+        Version: "2012-10-17"
+  PipelineBuildCodePipelineActionRoleDefaultPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - codebuild:BatchGetBuilds
+              - codebuild:StartBuild
+              - codebuild:StopBuild
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - BuildProject
+                - Arn
+        Version: "2012-10-17"
+      PolicyName: PipelineBuildCodePipelineActionRoleDefaultPolicy
+      Roles:
+        - Ref: PipelineBuildCodePipelineActionRole
+  PipelineDeployCodePipelineActionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":iam::"
+                    - Ref: AWS::AccountId
+                    - :root
+        Version: "2012-10-17"
+  PipelineDeployCodePipelineActionRoleDefaultPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - codebuild:BatchGetBuilds
+              - codebuild:StartBuild
+              - codebuild:StopBuild
+            Effect: Allow
+            Resource:
+              Fn::Join:
+                - ""
+                - - "arn:"
+                  - Ref: AWS::Partition
+                  - ":codebuild:"
+                  - Ref: AWS::Region
+                  - ":"
+                  - Ref: AWS::AccountId
+                  - ":project/Deploy*"
+        Version: "2012-10-17"
+      PolicyName: PipelineDeployCodePipelineActionRoleDefaultPolicy
+      Roles:
+        - Ref: PipelineDeployCodePipelineActionRole
+Outputs:
+  PipelineEndpoint:
+    Description: The URL to access the pipeline
+    Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/codesuite/codepipeline/pipelines/${Pipeline}/view?region=${AWS::Region}"

--- a/public-private-fargate-microservices/service/private-fargate-svc/pipeline/manifest.yaml
+++ b/public-private-fargate-microservices/service/private-fargate-svc/pipeline/manifest.yaml
@@ -1,0 +1,5 @@
+infrastructure:
+  templates:
+    - file: "cloudformation.yaml"
+      engine: jinja
+      template_language: cloudformation

--- a/public-private-fargate-microservices/service/private-fargate-svc/schema/schema.yaml
+++ b/public-private-fargate-microservices/service/private-fargate-svc/schema/schema.yaml
@@ -12,7 +12,7 @@ schema:
         port:
           type: number
           description: "The port to route traffic to"
-          default: 80
+          default: 8080
           minimum: 0
           maximum: 65535
         desired_count:
@@ -31,18 +31,12 @@ schema:
           default: "public.ecr.aws/z9d2n7e1/nginx:1.19.5"
           minLength: 1
           maxLength: 200
-        unique_name:
-          type: string
-          description: "The unique name of your service identifier. This will be used to name your log group, task definition and ECS service"
-          minLength: 1
-          maxLength: 100
         service_discovery_name:
           type: string
           description: "The name of the service to register in service discovery"
           minLength: 3
           maxLength: 24
       required:
-        - unique_name
         - service_discovery_name
 
     PipelineInputs:

--- a/public-private-fargate-microservices/service/private-fargate-svc/schema/schema.yaml
+++ b/public-private-fargate-microservices/service/private-fargate-svc/schema/schema.yaml
@@ -1,0 +1,63 @@
+schema:
+  format:
+    openapi: "3.0.0"
+  service_input_type: "PrivateServiceInput"
+  pipeline_input_type: "PipelineInputs"
+
+  types:
+    PrivateServiceInput:
+      type: object
+      description: "Input properties for a Private Fargate service"
+      properties:
+        port:
+          type: number
+          description: "The port to route traffic to"
+          default: 80
+          minimum: 0
+          maximum: 65535
+        desired_count:
+          type: number
+          description: "The default number of Fargate tasks you want running"
+          default: 1
+          minimum: 1
+        task_size:
+          type: string
+          description: "The size of the task you want to run"
+          enum: ["x-small", "small", "medium", "large", "x-large"]
+          default: "x-small"
+        image:
+          type: string
+          description: "The name/url of the container image"
+          default: "public.ecr.aws/z9d2n7e1/nginx:1.19.5"
+          minLength: 1
+          maxLength: 200
+        unique_name:
+          type: string
+          description: "The unique name of your service identifier. This will be used to name your log group, task definition and ECS service"
+          minLength: 1
+          maxLength: 100
+        service_discovery_name:
+          type: string
+          description: "The name of the service to register in service discovery"
+          minLength: 3
+          maxLength: 24
+      required:
+        - unique_name
+        - service_discovery_name
+
+    PipelineInputs:
+      type: object
+      description: "Pipeline input properties"
+      properties:
+        dockerfile:
+          type: string
+          description: "The location of the Dockerfile to build"
+          default: "Dockerfile"
+          minLength: 1
+          maxLength: 100
+        unit_test_command:
+          type: string
+          description: "The command to run to unit test the application code"
+          default: "echo 'add your unit test command here'"
+          minLength: 1
+          maxLength: 200

--- a/public-private-fargate-microservices/specs/env-spec.yaml
+++ b/public-private-fargate-microservices/specs/env-spec.yaml
@@ -1,0 +1,3 @@
+proton: EnvironmentSpec
+spec:
+  vpc_cidr: "10.0.0.0/16"

--- a/public-private-fargate-microservices/specs/svc-private-spec.yaml
+++ b/public-private-fargate-microservices/specs/svc-private-spec.yaml
@@ -10,5 +10,4 @@ instances:
       desired_count: 2
       port: 80
       task_size: "medium"
-      unique_name: "backend-dev"
       service_discovery_name: "backend-dev"

--- a/public-private-fargate-microservices/specs/svc-private-spec.yaml
+++ b/public-private-fargate-microservices/specs/svc-private-spec.yaml
@@ -1,0 +1,14 @@
+proton: ServiceSpec
+
+pipeline:
+  unit_test_command: "ls"
+
+instances:
+  - name: "backend-dev"
+    environment: "Beta"
+    spec:
+      desired_count: 2
+      port: 80
+      task_size: "medium"
+      unique_name: "backend-dev"
+      service_discovery_name: "backend-dev"

--- a/public-private-fargate-microservices/specs/svc-public-spec.yaml
+++ b/public-private-fargate-microservices/specs/svc-public-spec.yaml
@@ -1,0 +1,14 @@
+proton: ServiceSpec
+
+pipeline:
+  unit_test_command: "ls"
+
+instances:
+  - name: "frontend-dev"
+    environment: "Beta"
+    spec:
+      desired_count: 2
+      port: 80
+      task_size: "medium"
+      unique_name: "frontend-dev"
+      service_discovery_name: "frontend-dev"

--- a/public-private-fargate-microservices/specs/svc-public-spec.yaml
+++ b/public-private-fargate-microservices/specs/svc-public-spec.yaml
@@ -10,5 +10,4 @@ instances:
       desired_count: 2
       port: 80
       task_size: "medium"
-      unique_name: "frontend-dev"
       service_discovery_name: "frontend-dev"


### PR DESCRIPTION
*Description of changes:*
This PR implements a new directory `public-private-fargate-microservices` containing a sample AWS Proton Environment and 2 Service templates (Public & Private), a set of Amazon ECS based microservices using service discovery and running on AWS Fargate, as well as sample specs for creating Proton Environments and Services using the templates. All resources deployed are tagged.
Based on the existing `loadbalanced-fargate-svc` this sample deploys:
- a VPC
- an Internet Gateway
- 2 Nat Gateways across 2 Availability Zones
- 2 private subnets across 2 Availability Zones
- 2 public subnets across 2 Availability Zones
- an ECS Cluster
- a private namespace for service discovery

The service templates contains all the resources required to create a public ECS Fargate service behind a load balancer and a private ECS Fargate service in that environment taking the following options for configuration:
- Fargate CPU size
- Fargate memory size
- Number of running containers
- Choose private or public subnets to run the loadbalanced service or the private service, accessed via service discovery
- Service name to register and use for service discovery

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
