### PR TITLE
fixing incorrect svc name in README

### DIFF
--- a/public-private-fargate-microservices/README.md
+++ b/public-private-fargate-microservices/README.md
@@ -374,7 +374,7 @@ aws proton-preview create-service \
   --repository-id "<your-source-repo-account>/<your-repository-name>" \
   --branch "main" \
   --template-major-version-id 1 \
-  --service-template-arn arn:aws:proton:us-east-2:${account_id}:service-template/lb-private-fargate-svc \
+  --service-template-arn arn:aws:proton:us-east-2:${account_id}:service-template/private-fargate-svc \
   --spec file://specs/svc-private-spec.yaml
 ```
 


### PR DESCRIPTION
*Description of changes:*

This PR fixes the incorrect private svc name used in the README for the `public-private-fargate-microservices` sample.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
