### PR TITLE
Update instructions and pipeline templates for Proton API parameters that have been renamed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+## IMPORTANT
+
+Proton is making breaking API changes between 5/21/21 and 6/x/21 in preparation for launching into the SDK.  For more information, visit our [migration guide](https://docs.aws.amazon.com/proton/latest/adminguide/ga-api-migration.html).  If possible, we recommend using the console, which won't have a disruption in service, or wait until we launch in the SDK.
+
+If you want to keep using the CLI, at some point it will stop working.  The instructions on this branch have been updated to include the API changes, which are detailed in the [migration guide](https://docs.aws.amazon.com/proton/latest/adminguide/ga-api-migration.html).
+
+If this doesn't work for you, it's likely that Proton hasn't rolled out the API changes to your region.  In that case, go to the `old-api` [branch](https://github.com/aws-samples/aws-proton-sample-templates/tree/old-api) and use the instructions from there.
+
+Once we are launched in the official AWS SDK and CLI, we will update this repo to use standard practices.  For our loyal customers, we appreciate you, sorry for any trouble, and we hope you enjoy the new API.
+
 ## AWS Proton sample templates
 
 This repository is a curated list of sample templates to use with AWS Proton. AWS Proton is an application delivery service available at [aws.amazon.com/proton](https://aws.amazon.com/proton).

--- a/lambda-crud-svc/README.md
+++ b/lambda-crud-svc/README.md
@@ -109,7 +109,7 @@ aws proton-preview create-environment-template-minor-version \
   --region us-west-2 \
   --template-name "crud-api" \
   --description "Version 1" \
-  --major-version-id "1" \
+  --major-version "1" \
   --source-s3-bucket proton-cli-templates-${account_id} \
   --source-s3-key env-template.tar.gz
 ```
@@ -120,8 +120,8 @@ Wait for the environment template minor version to be successfully registered:
 aws proton-preview wait environment-template-registration-complete \
   --region us-west-2 \
   --template-name "crud-api" \
-  --major-version-id "1" \
-  --minor-version-id "0"
+  --major-version "1" \
+  --minor-version "0"
 ```
 
 You can now publish the environment template minor version, making it available for users in your AWS account to create Proton environments.
@@ -130,8 +130,8 @@ You can now publish the environment template minor version, making it available 
 aws proton-preview update-environment-template-minor-version \
   --region us-west-2 \
   --template-name "crud-api" \
-  --major-version-id "1" \
-  --minor-version-id "0" \
+  --major-version "1" \
+  --minor-version "0" \
   --status "PUBLISHED"
 ```
 
@@ -172,7 +172,7 @@ aws proton-preview create-service-template-minor-version \
   --region us-west-2 \
   --template-name "crud-api-service" \
   --description "Version 1" \
-  --major-version-id "1" \
+  --major-version "1" \
   --source-s3-bucket proton-cli-templates-${account_id} \
   --source-s3-key svc-template.tar.gz
 ```
@@ -183,8 +183,8 @@ Wait for the service template minor version to be successfully registered:
 aws proton-preview wait service-template-registration-complete \
   --region us-west-2 \
   --template-name "crud-api-service" \
-  --major-version-id "1" \
-  --minor-version-id "0"
+  --major-version "1" \
+  --minor-version "0"
 ```
 
 You can now publish the service template minor version, making it available for users in your AWS account to create Proton services.
@@ -193,8 +193,8 @@ You can now publish the service template minor version, making it available for 
 aws proton-preview update-service-template-minor-version \
   --region us-west-2 \
   --template-name "crud-api-service" \
-  --major-version-id "1" \
-  --minor-version-id "0" \
+  --major-version "1" \
+  --minor-version "0" \
   --status "PUBLISHED"
 ```
 
@@ -207,9 +207,9 @@ First, deploy a Proton environment. This command reads your environment spec at 
 ```
 aws proton-preview create-environment \
   --region us-west-2 \
-  --environment-name "crud-api-beta" \
-  --environment-template-arn arn:aws:proton:us-west-2:${account_id}:environment-template/crud-api \
-  --template-major-version-id 1 \
+  --name "crud-api-beta" \
+  --template-name crud-api \
+  --template-major-version 1 \
   --proton-service-role-arn arn:aws:iam::${account_id}:role/ProtonServiceRole \
   --spec file://specs/env-spec.yaml
 ```
@@ -219,7 +219,7 @@ Wait for the environment to successfully deploy.
 ```
 aws proton-preview wait environment-deployment-complete \
   --region us-west-2 \
-  --environment-name "crud-api-beta"
+  --name "crud-api-beta"
 ```
 
 Then, create a Proton service and deploy it into your Proton environment.  This command reads your service spec at `specs/svc-spec.yaml`, merges it with the service template created above, and deploys the resources in CloudFormation stacks in your AWS account using the Proton service role.  The service will provision a Lambda-based CRUD API endpoint and a CodePipeline pipeline to deploy your application code.
@@ -229,12 +229,12 @@ Fill in your CodeStar Connections connection ID and your source code repository 
 ```
 aws proton-preview create-service \
   --region us-west-2 \
-  --service-name "tasks-front-end" \
+  --name "tasks-front-end" \
   --repository-connection-arn arn:aws:codestar-connections:us-west-2:${account_id}:connection/<your-codestar-connection-id> \
   --repository-id "<your-source-repo-account>/<your-repository-name>" \
   --branch "main" \
-  --template-major-version-id 1 \
-  --service-template-arn arn:aws:proton:us-west-2:${account_id}:service-template/crud-api-service \
+  --template-major-version 1 \
+  --template-name crud-api-service \
   --spec file://specs/svc-spec.yaml
 ```
 
@@ -243,22 +243,5 @@ Wait for the service to successfully deploy.
 ```
 aws proton-preview wait service-creation-complete \
   --region us-west-2 \
-  --service-name "tasks-front-end"
-```
-
-Once the service is created, retrieve the CodePipeline pipeline console URL and the CRUD API endpoint URL for your service.
-
-```
-aws proton-preview get-service \
-  --region us-west-2 \
-  --service-name "tasks-front-end" \
-  --query "service.pipeline.outputs" \
-  --output text
-
-aws proton-preview get-service-instance \
-  --region us-west-2 \
-  --service-name "tasks-front-end" \
-  --service-instance-name "front-end" \
-  --query "serviceInstance.outputs" \
-  --output text
+  --name "tasks-front-end"
 ```

--- a/lambda-crud-svc/service/pipeline/cloudformation.yaml
+++ b/lambda-crud-svc/service/pipeline/cloudformation.yaml
@@ -64,7 +64,7 @@ Resources:
                     },
                     "post_build": {
                       "commands": [
-                        "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION get-service --service-name $service_name | jq -r .service.spec > service.yaml",
+                        "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION get-service --name-name $service_name | jq -r .service.spec > service.yaml",
                         "yq w service.yaml 'instances[*].spec.code_uri' \"$FUNCTION_URI\" > rendered_service.yaml"
                       ]
                     }
@@ -117,8 +117,8 @@ Resources:
               },
               "build": {
                 "commands": [
-                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --version-update-type UPDATE_SPEC --service-instance-name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
-                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --service-instance-name $service_instance_name --service-name $service_name"
+                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --deployment-type CURRENT_VERSION --name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
+                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --name $service_instance_name --service-name $service_name"
                 ]
               }
             }

--- a/loadbalanced-fargate-svc/README.md
+++ b/loadbalanced-fargate-svc/README.md
@@ -108,7 +108,7 @@ aws proton-preview create-environment-template-minor-version \
   --region us-west-2 \
   --template-name "public-vpc" \
   --description "Version 2" \
-  --major-version-id "1" \
+  --major-version "1" \
   --source-s3-bucket proton-cli-templates-${account_id} \
   --source-s3-key env-template.tar.gz
 ```
@@ -119,8 +119,8 @@ Wait for the environment template minor version to be successfully registered:
 aws proton-preview wait environment-template-registration-complete \
   --region us-west-2 \
   --template-name "public-vpc" \
-  --major-version-id "1" \
-  --minor-version-id "0"
+  --major-version "1" \
+  --minor-version "0"
 ```
 
 You can now publish the environment template minor version, making it available for users in your AWS account to create Proton environments.
@@ -129,8 +129,8 @@ You can now publish the environment template minor version, making it available 
 aws proton-preview update-environment-template-minor-version \
   --region us-west-2 \
   --template-name "public-vpc" \
-  --major-version-id "1" \
-  --minor-version-id "0" \
+  --major-version "1" \
+  --minor-version "0" \
   --status "PUBLISHED"
 ```
 
@@ -171,7 +171,7 @@ aws proton-preview create-service-template-minor-version \
   --region us-west-2 \
   --template-name "lb-fargate-service" \
   --description "Version 1" \
-  --major-version-id "1" \
+  --major-version "1" \
   --source-s3-bucket proton-cli-templates-${account_id} \
   --source-s3-key svc-template.tar.gz
 ```
@@ -182,8 +182,8 @@ Wait for the service template minor version to be successfully registered:
 aws proton-preview wait service-template-registration-complete \
   --region us-west-2 \
   --template-name "lb-fargate-service" \
-  --major-version-id "1" \
-  --minor-version-id "0"
+  --major-version "1" \
+  --minor-version "0"
 ```
 
 You can now publish the service template minor version, making it available for users in your AWS account to create Proton services.
@@ -192,8 +192,8 @@ You can now publish the service template minor version, making it available for 
 aws proton-preview update-service-template-minor-version \
   --region us-west-2 \
   --template-name "lb-fargate-service" \
-  --major-version-id "1" \
-  --minor-version-id "0" \
+  --major-version "1" \
+  --minor-version "0" \
   --status "PUBLISHED"
 ```
 
@@ -206,9 +206,9 @@ First, deploy a Proton environment. This command reads your environment spec at 
 ```
 aws proton-preview create-environment \
   --region us-west-2 \
-  --environment-name "Beta" \
-  --environment-template-arn arn:aws:proton:us-west-2:${account_id}:environment-template/public-vpc \
-  --template-major-version-id 1 \
+  --name "Beta" \
+  --template-name public-vpc \
+  --template-major-version 1 \
   --proton-service-role-arn arn:aws:iam::${account_id}:role/ProtonServiceRole \
   --spec file://specs/env-spec.yaml
 ```
@@ -218,7 +218,7 @@ Wait for the environment to successfully deploy.
 ```
 aws proton-preview wait environment-deployment-complete \
   --region us-west-2 \
-  --environment-name "Beta"
+  --name "Beta"
 ```
 
 Then, create a Proton service and deploy it into your Proton environment.  This command reads your service spec at `specs/svc-spec.yaml`, merges it with the service template created above, and deploys the resources in CloudFormation stacks in your AWS account using the Proton service role.  The service will provision a load-balanced ECS service running on Fargate and a CodePipeline pipeline to deploy your application code.
@@ -228,12 +228,12 @@ Fill in your CodeStar Connections connection ID and your source code repository 
 ```
 aws proton-preview create-service \
   --region us-west-2 \
-  --service-name "front-end" \
+  --name "front-end" \
   --repository-connection-arn arn:aws:codestar-connections:us-west-2:${account_id}:connection/<your-codestar-connection-id> \
   --repository-id "<your-source-repo-account>/<your-repository-name>" \
   --branch "main" \
-  --template-major-version-id 1 \
-  --service-template-arn arn:aws:proton:us-west-2:${account_id}:service-template/lb-fargate-service \
+  --template-major-version 1 \
+  --template-name lb-fargate-service \
   --spec file://specs/svc-spec.yaml
 ```
 
@@ -243,21 +243,4 @@ Wait for the service to successfully deploy.
 aws proton-preview wait service-creation-complete \
   --region us-west-2 \
   --service-name "front-end"
-```
-
-Once the service is created, retrieve the CodePipeline pipeline console URL and the CRUD API endpoint URL for your service.
-
-```
-aws proton-preview get-service \
-  --region us-west-2 \
-  --service-name "front-end" \
-  --query "service.pipeline.outputs" \
-  --output text
-
-aws proton-preview get-service-instance \
-  --region us-west-2 \
-  --service-name "front-end" \
-  --service-instance-name "frontend-dev" \
-  --query "serviceInstance.outputs" \
-  --output text
 ```

--- a/loadbalanced-fargate-svc/service/pipeline/cloudformation.yaml
+++ b/loadbalanced-fargate-svc/service/pipeline/cloudformation.yaml
@@ -69,7 +69,7 @@ Resources:
                     },
                     "post_build": {
                       "commands": [
-                        "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION get-service --service-name $service_name | jq -r .service.spec > service.yaml",
+                        "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION get-service --name-name $service_name | jq -r .service.spec > service.yaml",
                         "yq w service.yaml 'instances[*].spec.image' \"$IMAGE_ID\" > rendered_service.yaml"
                       ]
                     }
@@ -122,8 +122,8 @@ Resources:
               },
               "build": {
                 "commands": [
-                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --version-update-type UPDATE_SPEC --service-instance-name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
-                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --service-instance-name $service_instance_name --service-name $service_name"
+                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --deployment-type CURRENT_VERSION --name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
+                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --name $service_instance_name --service-name $service_name"
                 ]
               }
             }

--- a/public-private-fargate-microservices/README.md
+++ b/public-private-fargate-microservices/README.md
@@ -96,7 +96,7 @@ aws proton-preview \
   --endpoint-url https://proton.us-east-2.amazonaws.com \
   --region us-east-2 \
   create-environment-template \
-  --template-name "aws-proton-fargate-microservices" \
+  --name "aws-proton-fargate-microservices" \
   --display-name "aws proton fargate microservices" \
   --description "Proton Example Dev VPC with Public facing services and with Private backend services on ECS cluster with Fargate compute"
 ```
@@ -127,7 +127,7 @@ aws proton-preview \
   create-environment-template-minor-version \
   --template-name "aws-proton-fargate-microservices" \
   --description "Proton Example Dev Environment Version 1" \
-  --major-version-id "1" \
+  --major-version "1" \
   --source-s3-bucket proton-cli-templates-${account_id} \
   --source-s3-key env-template.tar.gz
 ```
@@ -138,8 +138,8 @@ Wait for the environment template minor version to be successfully registered:
 aws proton-preview wait environment-template-registration-complete \
   --region us-east-2 \
   --template-name "aws-proton-fargate-microservices" \
-  --major-version-id "1" \
-  --minor-version-id "0"
+  --major-version "1" \
+  --minor-version "0"
 ```
 
 You can now publish the environment template minor version, making it available for users in your AWS account to create Proton environments.
@@ -150,8 +150,8 @@ aws proton-preview \
   --region us-east-2 \
   update-environment-template-minor-version \
   --template-name "aws-proton-fargate-microservices" \
-  --major-version-id "1" \
-  --minor-version-id "0" \
+  --major-version "1" \
+  --minor-version "0" \
   --status "PUBLISHED"
 ```
 
@@ -198,7 +198,7 @@ aws proton-preview \
   create-service-template-minor-version \
   --template-name "lb-public-fargate-svc" \
   --description "Version 1" \
-  --major-version-id "1" \
+  --major-version "1" \
   --source-s3-bucket proton-cli-templates-${account_id} \
   --source-s3-key svc-private-template.tar.gz
 ```
@@ -211,8 +211,8 @@ aws proton-preview \
   --region us-east-2 \
   wait service-template-registration-complete \
   --template-name "lb-public-fargate-svc" \
-  --major-version-id "1" \
-  --minor-version-id "0"
+  --major-version "1" \
+  --minor-version "0"
 ```
 
 You can now publish the Public service template minor version, making it available for users in your AWS account to create Proton services.
@@ -223,8 +223,8 @@ aws proton-preview \
   --region us-east-2 \
   update-service-template-minor-version \
   --template-name "lb-public-fargate-svc" \
-  --major-version-id "1" \
-  --minor-version-id "0" \
+  --major-version "1" \
+  --minor-version "0" \
   --status "PUBLISHED"
 ```
 
@@ -267,7 +267,7 @@ aws proton-preview \
   create-service-template-minor-version \
   --template-name "private-fargate-svc" \
   --description "Version 1" \
-  --major-version-id "1" \
+  --major-version "1" \
   --source-s3-bucket proton-cli-templates-${account_id} \
   --source-s3-key svc-private-template.tar.gz
 ```
@@ -280,8 +280,8 @@ aws proton-preview \
   --region us-east-2 \
   wait service-template-registration-complete \
   --template-name "private-fargate-svc" \
-  --major-version-id "1" \
-  --minor-version-id "0"
+  --major-version "1" \
+  --minor-version "0"
 ```
 
 You can now publish the Public service template minor version, making it available for users in your AWS account to create Proton services.
@@ -292,8 +292,8 @@ aws proton-preview \
   --region us-east-2 \
   update-service-template-minor-version \
   --template-name "private-fargate-svc" \
-  --major-version-id "1" \
-  --minor-version-id "0" \
+  --major-version "1" \
+  --minor-version "0" \
   --status "PUBLISHED"
 ```
 
@@ -306,9 +306,9 @@ First, deploy a Proton environment. This command reads your environment spec at 
 ```
 aws proton-preview create-environment \
   --region us-east-2 \
-  --environment-name "Beta" \
-  --environment-template-arn arn:aws:proton:us-east-2:${account_id}:environment-template/aws-proton-fargate-microservices \
-  --template-major-version-id 1 \
+  --name "Beta" \
+  --template-name aws-proton-fargate-microservices \
+  --template-major-version 1 \
   --proton-service-role-arn arn:aws:iam::${account_id}:role/ProtonServiceRole \
   --spec file://specs/env-spec.yaml
 ```
@@ -318,7 +318,7 @@ Wait for the environment to successfully deploy.
 ```
 aws proton-preview wait environment-deployment-complete \
   --region us-east-2 \
-  --environment-name "Beta"
+  --name "Beta"
 ```
 
 Then, create a Public Proton service and deploy it into your Proton environment.  This command reads your service spec at `specs/svc-public-spec.yaml`, merges it with the service template created above, and deploys the resources in CloudFormation stacks in your AWS account using the Proton service role.  The service will provision a load-balanced ECS service running on Fargate and a CodePipeline pipeline to deploy your application code.
@@ -328,12 +328,12 @@ Fill in your CodeStar Connections connection ID and your source code repository 
 ```
 aws proton-preview create-service \
   --region us-east-2 \
-  --service-name "front-end" \
+  --name "front-end" \
   --repository-connection-arn arn:aws:codestar-connections:us-east-2:${account_id}:connection/<your-codestar-connection-id> \
   --repository-id "<your-source-repo-account>/<your-repository-name>" \
   --branch "main" \
-  --template-major-version-id 1 \
-  --service-template-arn arn:aws:proton:us-east-2:${account_id}:service-template/lb-public-fargate-svc \
+  --template-major-version 1 \
+  --template-name lb-public-fargate-svc \
   --spec file://specs/svc-public-spec.yaml
 ```
 
@@ -342,24 +342,7 @@ Wait for the service to successfully deploy.
 ```
 aws proton-preview wait service-creation-complete \
   --region us-east-2 \
-  --service-name "front-end"
-```
-
-Once the service is created, retrieve the CodePipeline pipeline console URL and the CRUD API endpoint URL for your service.
-
-```
-aws proton-preview get-service \
-  --region us-east-2 \
-  --service-name "front-end" \
-  --query "service.pipeline.outputs" \
-  --output text
-
-aws proton-preview get-service-instance \
-  --region us-east-2 \
-  --service-name "front-end" \
-  --service-instance-name "frontend-dev" \
-  --query "serviceInstance.outputs" \
-  --output text
+  --name "front-end"
 ```
 
 And finally, create a Private Proton service and deploy it into your Proton environment.  This command reads your service spec at `specs/svc-private-spec.yaml`, merges it with the service template created above, and deploys the resources in CloudFormation stacks in your AWS account using the Proton service role. The service will provision a private ECS service running on Fargate and a CodePipeline pipeline to deploy your application code.
@@ -369,12 +352,12 @@ Fill in your CodeStar Connections connection ID and your source code repository 
 ```
 aws proton-preview create-service \
   --region us-east-2 \
-  --service-name "back-end" \
+  --name "back-end" \
   --repository-connection-arn arn:aws:codestar-connections:us-east-2:${account_id}:connection/<your-codestar-connection-id> \
   --repository-id "<your-source-repo-account>/<your-repository-name>" \
   --branch "main" \
-  --template-major-version-id 1 \
-  --service-template-arn arn:aws:proton:us-east-2:${account_id}:service-template/private-fargate-svc \
+  --template-major-version 1 \
+  --template-name private-fargate-svc \
   --spec file://specs/svc-private-spec.yaml
 ```
 
@@ -383,22 +366,5 @@ Wait for the service to successfully deploy.
 ```
 aws proton-preview wait service-creation-complete \
   --region us-east-2 \
-  --service-name "back-end"
-```
-
-Once the service is created, retrieve the CodePipeline pipeline console URL and the CRUD API endpoint URL for your service.
-
-```
-aws proton-preview get-service \
-  --region us-east-2 \
-  --service-name "back-end" \
-  --query "service.pipeline.outputs" \
-  --output text
-
-aws proton-preview get-service-instance \
-  --region us-east-2 \
-  --service-name "back-end" \
-  --service-instance-name "backend-dev" \
-  --query "serviceInstance.outputs" \
-  --output text
+  --name "back-end"
 ```

--- a/public-private-fargate-microservices/service/loadbalanced-public-svc/pipeline/cloudformation.yaml
+++ b/public-private-fargate-microservices/service/loadbalanced-public-svc/pipeline/cloudformation.yaml
@@ -69,7 +69,7 @@ Resources:
                     },
                     "post_build": {
                       "commands": [
-                        "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION get-service --service-name $service_name | jq -r .service.spec > service.yaml",
+                        "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION get-service --name-name $service_name | jq -r .service.spec > service.yaml",
                         "yq w service.yaml 'instances[*].spec.image' \"$IMAGE_ID\" > rendered_service.yaml"
                       ]
                     }
@@ -122,8 +122,8 @@ Resources:
               },
               "build": {
                 "commands": [
-                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --version-update-type UPDATE_SPEC --service-instance-name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
-                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --service-instance-name $service_instance_name --service-name $service_name"
+                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --deployment-type CURRENT_VERSION --name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
+                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --name $service_instance_name --service-name $service_name"
                 ]
               }
             }

--- a/public-private-fargate-microservices/service/private-fargate-svc/pipeline/cloudformation.yaml
+++ b/public-private-fargate-microservices/service/private-fargate-svc/pipeline/cloudformation.yaml
@@ -69,7 +69,7 @@ Resources:
                     },
                     "post_build": {
                       "commands": [
-                        "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION get-service --service-name $service_name | jq -r .service.spec > service.yaml",
+                        "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION get-service --name-name $service_name | jq -r .service.spec > service.yaml",
                         "yq w service.yaml 'instances[*].spec.image' \"$IMAGE_ID\" > rendered_service.yaml"
                       ]
                     }
@@ -122,8 +122,8 @@ Resources:
               },
               "build": {
                 "commands": [
-                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --version-update-type UPDATE_SPEC --service-instance-name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
-                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --service-instance-name $service_instance_name --service-name $service_name"
+                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --deployment-type CURRENT_VERSION --name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
+                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --name $service_instance_name --service-name $service_name"
                 ]
               }
             }


### PR DESCRIPTION
AWS Proton was launched in December 2020 at re:invent for public preview. We were really excited to introduce AWS Proton to customers. It’s been 6 months since then. During that time we’ve been developing the features that are important to customers and making sure AWS Proton lives up to the operational standards of AWS. Additionally, we’ve been refining our API.

Unless you’re using the console, an API is the way you communicate with us. We want to make that communication as easy and natural as possible. After meeting with our customers and carefully re-examinating our APIs, we decided that the API needed some changes.

Unfortunately many of these are breaking changes. Now, the AWS SDK doesn’t break APIs. So we purposely didn’t launch in the AWS SDK for our public preview release because we wanted to keep API improvement opportunities open. That is why you could only access AWS Proton thru the console and the AWS CLI (using [this] (https://docs.aws.amazon.com/cli/latest/reference/configure/add-model.html) feature). 

This updates the readmes and pipeline templates to use the new input parameters.  

