### PR TITLE
Use the native CLI for when Proton is released in the SDK

### DIFF
--- a/lambda-multi-svc/README.md
+++ b/lambda-multi-svc/README.md
@@ -94,10 +94,10 @@ aws proton create-environment-template-version \
   --source s3="{bucket=proton-cli-templates-${account_id},key=env-template.tar.gz}"
 ```
 
-Wait 5 minutes for the environment template to be successfully registered. You can try this command to see if the template is in REGISTRATION_COMPLETE status
+Wait for the environment template version to be successfully registered. You can try this command to see the registration status
 
 ```bash
-aws proton get-environment-template \
+aws proton get-environment-template-version \
   --region us-west-2 \
   --template-name "multi-svc-env" \
   --major-version "1" \
@@ -146,10 +146,10 @@ aws proton create-service-template-version \
   --compatible-environment-templates '[{"templateName":"multi-svc-env","majorVersion":"1"}]'
 ```
 
-Wait 5 minutes for the service template to be successfully registered. You can try this command to see if the template is in REGISTRATION_COMPLETE status
+Wait for the service template version to be successfully registered. You can try this command to see the registration status
 
 ```bash
-aws proton get-service-template \
+aws proton get-service-template-version \
   --region us-west-2 \
   --template-name "crud-api-service" \
   --major-version "1" \

--- a/lambda-multi-svc/README.md
+++ b/lambda-multi-svc/README.md
@@ -25,18 +25,6 @@ First, make sure you have the AWS CLI installed and configured. Run the followin
 account_id=`aws sts get-caller-identity|jq -r ".Account"`
 ```
 
-### Configure the AWS CLI
-
-While AWS Proton is in Preview, you will need to manually configure the AWS CLI. The following commands will add the Proton commands to the AWS CLI.
-
-```bash
-aws s3 cp s3://aws-proton-preview-public-files/model/proton-2020-07-20.normal.json .
-aws s3 cp s3://aws-proton-preview-public-files/model/waiters2.json .
-aws configure add-model --service-model file://proton-2020-07-20.normal.json --service-name proton-preview
-mv waiters2.json ~/.aws/models/proton-preview/2020-07-20/waiters-2.json
-rm proton-2020-07-20.normal.json
-```
-
 ### Configure IAM Role, S3 Bucket, and CodeStar Connections Connection
 
 Before you register your templates and deploy your environments and services, you will need to create an Amazon IAM role so that AWS Proton can manage resources in your AWS account, an Amazon S3 bucket to store your templates, and a CodeStar Connections connection to pull and deploy your application code.
@@ -65,7 +53,7 @@ aws iam attach-role-policy \
 Then, allow Proton to use that role to provision resources for your services' continuous delivery pipelines:
 
 ```bash
-aws proton-preview update-account-settings \
+aws proton update-account-settings \
   --region us-west-2 \
   --pipeline-service-role-arn "arn:aws:iam::${account_id}:role/ProtonServiceRole"
 ```
@@ -83,7 +71,7 @@ Register the sample environment template, which contains a simple Amazon DynamoD
 First, create an environment template, which will contain all of the environment template's versions.
 
 ```bash
-aws proton-preview create-environment-template \
+aws proton create-environment-template \
   --region us-west-2 \
   --name "multi-svc-env" \
   --display-name "Multi Service Environment" \
@@ -99,7 +87,7 @@ aws s3 cp env-template.tar.gz s3://proton-cli-templates-${account_id}/env-templa
 
 rm env-template.tar.gz
 
-aws proton-preview create-environment-template-version \
+aws proton create-environment-template-version \
   --region us-west-2 \
   --template-name "multi-svc-env" \
   --description "Version 1" \
@@ -109,7 +97,7 @@ aws proton-preview create-environment-template-version \
 Wait for the environment template version to be successfully registered:
 
 ```bash
-aws proton-preview wait environment-template-registration-complete \
+aws proton wait environment-template-registration-complete \
   --region us-west-2 \
   --template-name "multi-svc-env" \
   --major-version "1" \
@@ -119,7 +107,7 @@ aws proton-preview wait environment-template-registration-complete \
 You can now publish the environment template version, making it available for users in your AWS account to create Proton environments.
 
 ```bash
-aws proton-preview update-environment-template-version \
+aws proton update-environment-template-version \
   --region us-west-2 \
   --template-name "multi-svc-env" \
   --major-version "1" \
@@ -134,7 +122,7 @@ Register the sample service template, which contains all the resources required 
 First, create the service template.
 
 ```bash
-aws proton-preview create-service-template \
+aws proton create-service-template \
   --region us-west-2 \
   --name "crud-api-service" \
   --display-name "CRUD API Service" \
@@ -150,7 +138,7 @@ aws s3 cp svc-template.tar.gz s3://proton-cli-templates-${account_id}/svc-templa
 
 rm svc-template.tar.gz
 
-aws proton-preview create-service-template-version \
+aws proton create-service-template-version \
   --region us-west-2 \
   --template-name "crud-api-service" \
   --description "Version 1" \
@@ -161,7 +149,7 @@ aws proton-preview create-service-template-version \
 Wait for the service template version to be successfully registered:
 
 ```bash
-aws proton-preview wait service-template-registration-complete \
+aws proton wait service-template-registration-complete \
   --region us-west-2 \
   --template-name "crud-api-service" \
   --major-version "1" \
@@ -171,7 +159,7 @@ aws proton-preview wait service-template-registration-complete \
 You can now publish the service template version, making it available for users in your AWS account to create Proton services.
 
 ```bash
-aws proton-preview update-service-template-version \
+aws proton update-service-template-version \
   --region us-west-2 \
   --template-name "crud-api-service" \
   --major-version "1" \
@@ -190,7 +178,7 @@ With the registered and published environment and service templates, you can now
 First, deploy a Proton environment. This command reads your environment spec at `specs/env-spec.yaml`, merges it with the environment template created above, and deploys the resources in a CloudFormation stack in your AWS account using the Proton service role.
 
 ```bash
-aws proton-preview create-environment \
+aws proton create-environment \
   --region us-west-2 \
   --name "multi-svc-beta" \
   --template-name multi-svc-env \
@@ -202,7 +190,7 @@ aws proton-preview create-environment \
 Wait for the environment to successfully deploy.
 
 ```bash
-aws proton-preview wait environment-deployment-complete \
+aws proton wait environment-deployment-complete \
   --region us-west-2 \
   --name "multi-svc-beta"
 ```
@@ -212,7 +200,7 @@ Then, create a Proton service and deploy it into your Proton environment.  This 
 Fill in your CodeStar Connections connection ID and your source code repository details in this command.
 
 ```bash
-aws proton-preview create-service \
+aws proton create-service \
   --region us-west-2 \
   --name "tasks-front-end" \
   --repository-connection-arn arn:aws:codestar-connections:us-west-2:${account_id}:connection/<your-codestar-connection-id> \
@@ -226,7 +214,7 @@ aws proton-preview create-service \
 Wait for the service to successfully deploy.
 
 ```bash
-aws proton-preview wait service-creation-complete \
+aws proton wait service-creation-complete \
   --region us-west-2 \
   --name "tasks-front-end"
 ```

--- a/lambda-multi-svc/README.md
+++ b/lambda-multi-svc/README.md
@@ -94,10 +94,10 @@ aws proton create-environment-template-version \
   --source s3="{bucket=proton-cli-templates-${account_id},key=env-template.tar.gz}"
 ```
 
-Wait for the environment template version to be successfully registered:
+Wait 5 minutes for the environment template to be successfully registered. You can try this command to see if the template is in REGISTRATION_COMPLETE status
 
 ```bash
-aws proton wait environment-template-registration-complete \
+aws proton get-environment-template \
   --region us-west-2 \
   --template-name "multi-svc-env" \
   --major-version "1" \
@@ -146,10 +146,10 @@ aws proton create-service-template-version \
   --compatible-environment-templates '[{"templateName":"multi-svc-env","majorVersion":"1"}]'
 ```
 
-Wait for the service template version to be successfully registered:
+Wait 5 minutes for the service template to be successfully registered. You can try this command to see if the template is in REGISTRATION_COMPLETE status
 
 ```bash
-aws proton wait service-template-registration-complete \
+aws proton get-service-template \
   --region us-west-2 \
   --template-name "crud-api-service" \
   --major-version "1" \
@@ -187,10 +187,10 @@ aws proton create-environment \
   --spec file://specs/env-spec.yaml
 ```
 
-Wait for the environment to successfully deploy.
+Wait for the environment to successfully deploy. Use this call to check for deployment status:
 
 ```bash
-aws proton wait environment-deployment-complete \
+aws proton get-environment \
   --region us-west-2 \
   --name "multi-svc-beta"
 ```
@@ -211,10 +211,10 @@ aws proton create-service \
   --spec file://specs/svc-spec.yaml
 ```
 
-Wait for the service to successfully deploy.
+Wait for the service to successfully deploy. Use this call to check for deployment status:
 
 ```bash
-aws proton wait service-creation-complete \
+aws proton get-service \
   --region us-west-2 \
   --name "tasks-front-end"
 ```

--- a/lambda-multi-svc/service-crud/pipeline_infrastructure/cloudformation.yaml
+++ b/lambda-multi-svc/service-crud/pipeline_infrastructure/cloudformation.yaml
@@ -38,10 +38,6 @@ Resources:
                             "dotnetcore3.1": {"dotnet": "3.1"}
                           }[service_instances[0].outputs.LambdaRuntime] | tojson | safe }},
                       "commands": [
-                        "aws s3 cp s3://aws-proton-preview-public-files/model/proton-2020-07-20.normal.json .",
-                        "aws s3 cp s3://aws-proton-preview-public-files/model/waiters2.json .",
-                        "aws configure add-model --service-model file://proton-2020-07-20.normal.json --service-name proton-preview",
-                        "mv waiters2.json ~/.aws/models/proton-preview/2020-07-20/waiters-2.json",
                         "echo 'f6bd1536a743ab170b35c94ed4c7c4479763356bd543af5d391122f4af852460  yq_linux_amd64' > yq_linux_amd64.sha",
                         "wget https://github.com/mikefarah/yq/releases/download/3.4.0/yq_linux_amd64",
                         "sha256sum -c yq_linux_amd64.sha",
@@ -64,7 +60,7 @@ Resources:
                     },
                     "post_build": {
                       "commands": [
-                        "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION get-service --name $service_name | jq -r .service.spec > service.yaml",
+                        "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION get-service --name $service_name | jq -r .service.spec > service.yaml",
                         "yq w service.yaml 'instances[*].spec.code_uri' \"$FUNCTION_URI\" > rendered_service.yaml"
                       ]
                     }
@@ -107,18 +103,10 @@ Resources:
           {
             "version": "0.2",
             "phases": {
-              "install": {
-                "commands": [
-                  "aws s3 cp s3://aws-proton-preview-public-files/model/proton-2020-07-20.normal.json .",
-                  "aws s3 cp s3://aws-proton-preview-public-files/model/waiters2.json .",
-                  "aws configure add-model --service-model file://proton-2020-07-20.normal.json --service-name proton-preview",
-                  "mv waiters2.json ~/.aws/models/proton-preview/2020-07-20/waiters-2.json"
-                ]
-              },
               "build": {
                 "commands": [
-                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --deployment-type CURRENT_VERSION --name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
-                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --name $service_instance_name --service-name $service_name"
+                  "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --deployment-type CURRENT_VERSION --name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
+                  "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --name $service_instance_name --service-name $service_name"
                 ]
               }
             }
@@ -194,10 +182,6 @@ Resources:
               - proton:GetService
             Effect: Allow
             Resource: "*"
-          - Action: s3:GetObject
-            Effect: Allow
-            Resource:
-              - "arn:aws:s3:::aws-proton-preview-public-files/*"
           - Action:
               - s3:GetObject*
               - s3:GetBucket*
@@ -322,10 +306,6 @@ Resources:
               - proton:GetServiceInstance
             Effect: Allow
             Resource: "*"
-          - Action: s3:GetObject
-            Effect: Allow
-            Resource:
-              - "arn:aws:s3:::aws-proton-preview-public-files/*"
           - Action:
               - s3:GetObject*
               - s3:GetBucket*

--- a/lambda-multi-svc/service-data-processing/pipeline_infrastructure/cloudformation.yaml
+++ b/lambda-multi-svc/service-data-processing/pipeline_infrastructure/cloudformation.yaml
@@ -38,10 +38,6 @@ Resources:
                             "dotnetcore3.1": {"dotnet": "3.1"}
                           }[service_instances[0].outputs.LambdaRuntime] | tojson | safe }},
                       "commands": [
-                        "aws s3 cp s3://aws-proton-preview-public-files/model/proton-2020-07-20.normal.json .",
-                        "aws s3 cp s3://aws-proton-preview-public-files/model/waiters2.json .",
-                        "aws configure add-model --service-model file://proton-2020-07-20.normal.json --service-name proton-preview",
-                        "mv waiters2.json ~/.aws/models/proton-preview/2020-07-20/waiters-2.json",
                         "echo 'f6bd1536a743ab170b35c94ed4c7c4479763356bd543af5d391122f4af852460  yq_linux_amd64' > yq_linux_amd64.sha",
                         "wget https://github.com/mikefarah/yq/releases/download/3.4.0/yq_linux_amd64",
                         "sha256sum -c yq_linux_amd64.sha",
@@ -64,7 +60,7 @@ Resources:
                     },
                     "post_build": {
                       "commands": [
-                        "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION get-service --name $service_name | jq -r .service.spec > service.yaml",
+                        "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION get-service --name $service_name | jq -r .service.spec > service.yaml",
                         "yq w service.yaml 'instances[*].spec.code_uri' \"$FUNCTION_URI\" > rendered_service.yaml"
                       ]
                     }
@@ -107,18 +103,10 @@ Resources:
           {
             "version": "0.2",
             "phases": {
-              "install": {
-                "commands": [
-                  "aws s3 cp s3://aws-proton-preview-public-files/model/proton-2020-07-20.normal.json .",
-                  "aws s3 cp s3://aws-proton-preview-public-files/model/waiters2.json .",
-                  "aws configure add-model --service-model file://proton-2020-07-20.normal.json --service-name proton-preview",
-                  "mv waiters2.json ~/.aws/models/proton-preview/2020-07-20/waiters-2.json"
-                ]
-              },
               "build": {
                 "commands": [
-                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --version-update-type UPDATE_SPEC --name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
-                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --name $service_instance_name --service-name $service_name"
+                  "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --version-update-type UPDATE_SPEC --name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
+                  "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --name $service_instance_name --service-name $service_name"
                 ]
               }
             }
@@ -194,10 +182,6 @@ Resources:
               - proton:GetService
             Effect: Allow
             Resource: "*"
-          - Action: s3:GetObject
-            Effect: Allow
-            Resource:
-              - "arn:aws:s3:::aws-proton-preview-public-files/*"
           - Action:
               - s3:GetObject*
               - s3:GetBucket*
@@ -322,10 +306,6 @@ Resources:
               - proton:GetServiceInstance
             Effect: Allow
             Resource: "*"
-          - Action: s3:GetObject
-            Effect: Allow
-            Resource:
-              - "arn:aws:s3:::aws-proton-preview-public-files/*"
           - Action:
               - s3:GetObject*
               - s3:GetBucket*

--- a/loadbalanced-fargate-svc/README.md
+++ b/loadbalanced-fargate-svc/README.md
@@ -21,18 +21,6 @@ First, make sure you have the AWS CLI installed, and configured. Run the followi
 account_id=`aws sts get-caller-identity|jq -r ".Account"`
 ```
 
-### Configure the AWS CLI
-
-While AWS Proton is in preview, you will need to manually configure the AWS CLI. The following commands will add the Proton commands to the AWS CLI.
-
-```
-aws s3 cp s3://aws-proton-preview-public-files/model/proton-2020-07-20.normal.json .
-aws s3 cp s3://aws-proton-preview-public-files/model/waiters2.json .
-aws configure add-model --service-model file://proton-2020-07-20.normal.json --service-name proton-preview
-mv waiters2.json ~/.aws/models/proton-preview/2020-07-20/waiters-2.json
-rm proton-2020-07-20.normal.json
-```
-
 ### Configure IAM Role, S3 Bucket, and CodeStar Connections Connection
 
 Before you register your templates and deploy your environments and services, you will need to create an Amazon IAM role so that AWS Proton can manage resources in your AWS account, an Amazon S3 bucket to store your templates, and a CodeStar Connections connection to pull and deploy your application code.
@@ -61,7 +49,7 @@ aws iam attach-role-policy \
 Then, allow Proton to use that role to provision resources for your services' continuous delivery pipelines:
 
 ```
-aws proton-preview update-account-settings \
+aws proton update-account-settings \
   --region us-west-2 \
   --pipeline-service-role-arn "arn:aws:iam::${account_id}:role/ProtonServiceRole"
 ```
@@ -79,7 +67,7 @@ Register the sample environment template, which contains an ECS Cluster and a VP
 First, create an environment template, which will contain all of the environment template's versions.
 
 ```
-aws proton-preview create-environment-template \
+aws proton create-environment-template \
   --region us-west-2 \
   --name "public-vpc" \
   --display-name "PublicVPC" \
@@ -95,7 +83,7 @@ aws s3 cp env-template.tar.gz s3://proton-cli-templates-${account_id}/env-templa
 
 rm env-template.tar.gz
 
-aws proton-preview create-environment-template-version \
+aws proton create-environment-template-version \
   --region us-west-2 \
   --template-name "public-vpc" \
   --description "Version 2" \
@@ -105,7 +93,7 @@ aws proton-preview create-environment-template-version \
 Wait for the environment template version to be successfully registered:
 
 ```
-aws proton-preview wait environment-template-registration-complete \
+aws proton wait environment-template-registration-complete \
   --region us-west-2 \
   --template-name "public-vpc" \
   --major-version "1" \
@@ -115,7 +103,7 @@ aws proton-preview wait environment-template-registration-complete \
 You can now publish the environment template version, making it available for users in your AWS account to create Proton environments.
 
 ```
-aws proton-preview update-environment-template-version \
+aws proton update-environment-template-version \
   --region us-west-2 \
   --template-name "public-vpc" \
   --major-version "1" \
@@ -130,7 +118,7 @@ Register the sample service template, which contains all the resources required 
 First, create the service template.
 
 ```
-aws proton-preview create-service-template \
+aws proton create-service-template \
   --region us-west-2 \
   --name "lb-fargate-service" \
   --display-name "LoadbalancedFargateService" \
@@ -146,7 +134,7 @@ aws s3 cp svc-template.tar.gz s3://proton-cli-templates-${account_id}/svc-templa
 
 rm svc-template.tar.gz
 
-aws proton-preview create-service-template-version \
+aws proton create-service-template-version \
   --region us-west-2 \
   --template-name "lb-fargate-service" \
   --description "Version 1" \
@@ -158,7 +146,7 @@ aws proton-preview create-service-template-version \
 Wait for the service template version to be successfully registered:
 
 ```
-aws proton-preview wait service-template-registration-complete \
+aws proton wait service-template-registration-complete \
   --region us-west-2 \
   --template-name "lb-fargate-service" \
   --major-version "1" \
@@ -168,7 +156,7 @@ aws proton-preview wait service-template-registration-complete \
 You can now publish the service template version, making it available for users in your AWS account to create Proton services.
 
 ```
-aws proton-preview update-service-template-version \
+aws proton update-service-template-version \
   --region us-west-2 \
   --template-name "lb-fargate-service" \
   --major-version "1" \
@@ -183,7 +171,7 @@ With the registered and published environment and service templates, you can now
 First, deploy a Proton environment. This command reads your environment spec at `specs/env-spec.yaml`, merges it with the environment template created above, and deploys the resources in a CloudFormation stack in your AWS account using the Proton service role.
 
 ```
-aws proton-preview create-environment \
+aws proton create-environment \
   --region us-west-2 \
   --name "Beta" \
   --template-name public-vpc \
@@ -195,7 +183,7 @@ aws proton-preview create-environment \
 Wait for the environment to successfully deploy.
 
 ```
-aws proton-preview wait environment-deployment-complete \
+aws proton wait environment-deployment-complete \
   --region us-west-2 \
   --name "Beta"
 ```
@@ -205,7 +193,7 @@ Then, create a Proton service and deploy it into your Proton environment.  This 
 Fill in your CodeStar Connections connection ID and your source code repository details in this command.
 
 ```
-aws proton-preview create-service \
+aws proton create-service \
   --region us-west-2 \
   --name "front-end" \
   --repository-connection-arn arn:aws:codestar-connections:us-west-2:${account_id}:connection/<your-codestar-connection-id> \
@@ -219,7 +207,7 @@ aws proton-preview create-service \
 Wait for the service to successfully deploy.
 
 ```
-aws proton-preview wait service-creation-complete \
+aws proton wait service-creation-complete \
   --region us-west-2 \
   --service-name "front-end"
 ```

--- a/loadbalanced-fargate-svc/README.md
+++ b/loadbalanced-fargate-svc/README.md
@@ -90,10 +90,10 @@ aws proton create-environment-template-version \
   --source s3="{bucket=proton-cli-templates-${account_id},key=env-template.tar.gz}"
 ```
 
-Wait for the environment template version to be successfully registered:
+Wait for the environment template version to be successfully registered. Use this command to check for registration status:
 
 ```
-aws proton wait environment-template-registration-complete \
+aws proton get-environment-template \
   --region us-west-2 \
   --template-name "public-vpc" \
   --major-version "1" \
@@ -143,10 +143,10 @@ aws proton create-service-template-version \
   --compatible-environment-templates '[{"templateName":"public-vpc","majorVersion":"1"}]'
 ```
 
-Wait for the service template version to be successfully registered:
+Wait for the service template to be successfully registered. Use this command to check for registration status:
 
 ```
-aws proton wait service-template-registration-complete \
+aws proton get-service-template \
   --region us-west-2 \
   --template-name "lb-fargate-service" \
   --major-version "1" \
@@ -180,10 +180,10 @@ aws proton create-environment \
   --spec file://specs/env-spec.yaml
 ```
 
-Wait for the environment to successfully deploy.
+Wait for the environment to successfully deploy. Use this command to check for deployment status:
 
 ```
-aws proton wait environment-deployment-complete \
+aws proton get-environment \
   --region us-west-2 \
   --name "Beta"
 ```
@@ -204,10 +204,10 @@ aws proton create-service \
   --spec file://specs/svc-spec.yaml
 ```
 
-Wait for the service to successfully deploy.
+Wait for the service to successfully deploy. Use this command to check for deployment status:
 
 ```
-aws proton wait service-creation-complete \
+aws proton get-service \
   --region us-west-2 \
   --service-name "front-end"
 ```

--- a/loadbalanced-fargate-svc/README.md
+++ b/loadbalanced-fargate-svc/README.md
@@ -93,7 +93,7 @@ aws proton create-environment-template-version \
 Wait for the environment template version to be successfully registered. Use this command to check for registration status:
 
 ```
-aws proton get-environment-template \
+aws proton get-environment-template-version \
   --region us-west-2 \
   --template-name "public-vpc" \
   --major-version "1" \
@@ -146,7 +146,7 @@ aws proton create-service-template-version \
 Wait for the service template to be successfully registered. Use this command to check for registration status:
 
 ```
-aws proton get-service-template \
+aws proton get-service-template-version \
   --region us-west-2 \
   --template-name "lb-fargate-service" \
   --major-version "1" \

--- a/loadbalanced-fargate-svc/service/pipeline_infrastructure/cloudformation.yaml
+++ b/loadbalanced-fargate-svc/service/pipeline_infrastructure/cloudformation.yaml
@@ -36,10 +36,6 @@ Resources:
                         "docker": 18
                       },
                       "commands": [
-                        "aws s3 cp s3://aws-proton-preview-public-files/model/proton-2020-07-20.normal.json .",
-                        "aws s3 cp s3://aws-proton-preview-public-files/model/waiters2.json .",
-                        "aws configure add-model --service-model file://proton-2020-07-20.normal.json --service-name proton-preview",
-                        "mv waiters2.json ~/.aws/models/proton-preview/2020-07-20/waiters-2.json",
                         "echo 'f6bd1536a743ab170b35c94ed4c7c4479763356bd543af5d391122f4af852460  yq_linux_amd64' > yq_linux_amd64.sha",
                         "wget https://github.com/mikefarah/yq/releases/download/3.4.0/yq_linux_amd64",
                         "sha256sum -c yq_linux_amd64.sha",
@@ -69,7 +65,7 @@ Resources:
                     },
                     "post_build": {
                       "commands": [
-                        "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION get-service --name $service_name | jq -r .service.spec > service.yaml",
+                        "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION get-service --name $service_name | jq -r .service.spec > service.yaml",
                         "yq w service.yaml 'instances[*].spec.image' \"$IMAGE_ID\" > rendered_service.yaml"
                       ]
                     }
@@ -112,18 +108,10 @@ Resources:
           {
             "version": "0.2",
             "phases": {
-              "install": {
-                "commands": [
-                  "aws s3 cp s3://aws-proton-preview-public-files/model/proton-2020-07-20.normal.json .",
-                  "aws s3 cp s3://aws-proton-preview-public-files/model/waiters2.json .",
-                  "aws configure add-model --service-model file://proton-2020-07-20.normal.json --service-name proton-preview",
-                  "mv waiters2.json ~/.aws/models/proton-preview/2020-07-20/waiters-2.json"
-                ]
-              },
               "build": {
                 "commands": [
-                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --deployment-type CURRENT_VERSION --name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
-                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --name $service_instance_name --service-name $service_name"
+                  "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --deployment-type CURRENT_VERSION --name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
+                  "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --name $service_instance_name --service-name $service_name"
                 ]
               }
             }
@@ -215,10 +203,6 @@ Resources:
               - proton:GetService
             Effect: Allow
             Resource: "*"
-          - Action: s3:GetObject
-            Effect: Allow
-            Resource:
-              - "arn:aws:s3:::aws-proton-preview-public-files/*"
           - Action:
               - s3:GetObject*
               - s3:GetBucket*
@@ -324,10 +308,6 @@ Resources:
               - proton:GetServiceInstance
             Effect: Allow
             Resource: "*"
-          - Action: s3:GetObject
-            Effect: Allow
-            Resource:
-              - "arn:aws:s3:::aws-proton-preview-public-files/*"
           - Action:
               - s3:GetObject*
               - s3:GetBucket*

--- a/public-private-fargate-microservices/README.md
+++ b/public-private-fargate-microservices/README.md
@@ -100,17 +100,17 @@ rm env-template.tar.gz
 aws proton \
   --region us-east-2 \
   create-environment-template-version \
-  --template-name "aws-proton-fargate-microservices" \
+  --name "aws-proton-fargate-microservices" \
   --description "Proton Example Dev Environment Version 1" \
   --source s3="{bucket=proton-cli-templates-${account_id},key=env-template.tar.gz}"
 ```
 
-Wait for the environment template version to be successfully registered:
+Wait for the environment template version to be successfully registered. Use this command to verify status
 
 ```
-aws proton wait environment-template-registration-complete \
+aws proton get-environment-template \
   --region us-east-2 \
-  --template-name "aws-proton-fargate-microservices" \
+  --name "aws-proton-fargate-microservices" \
   --major-version "1" \
   --minor-version "0"
 ```
@@ -121,7 +121,7 @@ You can now publish the environment template version, making it available for us
 aws proton \
   --region us-east-2 \
   update-environment-template-version \
-  --template-name "aws-proton-fargate-microservices" \
+  --name "aws-proton-fargate-microservices" \
   --major-version "1" \
   --minor-version "0" \
   --status "PUBLISHED"
@@ -154,19 +154,18 @@ rm svc-private-template.tar.gz
 aws proton \
   --region us-east-2 \
   create-service-template-version \
-  --template-name "lb-public-fargate-svc" \
+  --name "lb-public-fargate-svc" \
   --description "Version 1" \
   --source s3="{bucket=proton-cli-templates-${account_id},key=svc-private-template.tar.gz}" \
   --compatible-environment-templates '[{"templateName":"aws-proton-fargate-microservices","majorVersion":"1"}]'
 ```
 
-Wait for the service template version to be successfully registered:
+Wait for the service template version to be successfully registered. Use this command to verify status
 
 ```
-aws proton \
+aws proton get-service-template \
   --region us-east-2 \
-  wait service-template-registration-complete \
-  --template-name "lb-public-fargate-svc" \
+  --name "lb-public-fargate-svc" \
   --major-version "1" \
   --minor-version "0"
 ```
@@ -177,7 +176,7 @@ You can now publish the Public service template version, making it available for
 aws proton \
   --region us-east-2 \
   update-service-template-version \
-  --template-name "lb-public-fargate-svc" \
+  --name "lb-public-fargate-svc" \
   --major-version "1" \
   --minor-version "0" \
   --status "PUBLISHED"
@@ -206,19 +205,19 @@ rm svc-private-template.tar.gz
 aws proton \
   --region us-east-2 \
   create-service-template-version \
-  --template-name "private-fargate-svc" \
+  --name "private-fargate-svc" \
   --description "Version 1" \
   --source s3="{bucket=proton-cli-templates-${account_id},key=svc-private-template.tar.gz}" \
   --compatible-environment-templates '[{"templateName":"aws-proton-fargate-microservices","majorVersion":"1"}]'
 ```
 
-Wait for the service template version to be successfully registered:
+Wait for the service template version to be successfully registered. Use this command to verify status
 
 ```
 aws proton \
   --region us-east-2 \
-  wait service-template-registration-complete \
-  --template-name "private-fargate-svc" \
+  get-service-template \
+  --name "private-fargate-svc" \
   --major-version "1" \
   --minor-version "0"
 ```
@@ -229,7 +228,7 @@ You can now publish the Public service template version, making it available for
 aws proton \
   --region us-east-2 \
   update-service-template-version \
-  --template-name "private-fargate-svc" \
+  --name "private-fargate-svc" \
   --major-version "1" \
   --minor-version "0" \
   --status "PUBLISHED"
@@ -251,10 +250,10 @@ aws proton create-environment \
   --spec file://specs/env-spec.yaml
 ```
 
-Wait for the environment to successfully deploy.
+Wait for the environment to successfully deploy. Use this command to verify deployment status:
 
 ```
-aws proton wait environment-deployment-complete \
+aws proton get-environment \
   --region us-east-2 \
   --name "Beta"
 ```
@@ -275,10 +274,10 @@ aws proton create-service \
   --spec file://specs/svc-public-spec.yaml
 ```
 
-Wait for the service to successfully deploy.
+Wait for the service to successfully deploy. Use this command to verify deployment status
 
 ```
-aws proton wait service-creation-complete \
+aws proton get-service \
   --region us-east-2 \
   --name "front-end"
 ```
@@ -299,10 +298,10 @@ aws proton create-service \
   --spec file://specs/svc-private-spec.yaml
 ```
 
-Wait for the service to successfully deploy.
+Wait for the service to successfully deploy. Use this command to verify deployment status:
 
 ```
-aws proton wait service-creation-complete \
+aws proton get-service \
   --region us-east-2 \
   --name "back-end"
 ```

--- a/public-private-fargate-microservices/README.md
+++ b/public-private-fargate-microservices/README.md
@@ -108,9 +108,9 @@ aws proton \
 Wait for the environment template version to be successfully registered. Use this command to verify status
 
 ```
-aws proton get-environment-template \
+aws proton get-environment-template-version \
   --region us-east-2 \
-  --name "aws-proton-fargate-microservices" \
+  --template-name "aws-proton-fargate-microservices" \
   --major-version "1" \
   --minor-version "0"
 ```
@@ -163,9 +163,9 @@ aws proton \
 Wait for the service template version to be successfully registered. Use this command to verify status
 
 ```
-aws proton get-service-template \
+aws proton get-service-template-version \
   --region us-east-2 \
-  --name "lb-public-fargate-svc" \
+  --template-name "lb-public-fargate-svc" \
   --major-version "1" \
   --minor-version "0"
 ```
@@ -228,7 +228,7 @@ You can now publish the Public service template version, making it available for
 aws proton \
   --region us-east-2 \
   update-service-template-version \
-  --name "private-fargate-svc" \
+  --template-name "private-fargate-svc" \
   --major-version "1" \
   --minor-version "0" \
   --status "PUBLISHED"

--- a/public-private-fargate-microservices/README.md
+++ b/public-private-fargate-microservices/README.md
@@ -34,18 +34,6 @@ First, make sure you have the AWS CLI installed, and configured. Run the followi
 account_id=`aws sts get-caller-identity|jq -r ".Account"`
 ```
 
-### Configure the AWS CLI
-
-While AWS Proton is in preview, you will need to manually configure the AWS CLI. The following commands will add the Proton commands to the AWS CLI.
-
-```
-aws s3 cp s3://aws-proton-preview-public-files/model/proton-2020-07-20.normal.json .
-aws s3 cp s3://aws-proton-preview-public-files/model/waiters2.json .
-aws configure add-model --service-model file://proton-2020-07-20.normal.json --service-name proton-preview
-mv waiters2.json ~/.aws/models/proton-preview/2020-07-20/waiters-2.json
-rm proton-2020-07-20.normal.json
-```
-
 ### Configure IAM Role, S3 Bucket, and CodeStar Connections Connection
 
 Before you register your templates and deploy your environments and services, you will need to create an Amazon IAM role so that AWS Proton can manage resources in your AWS account, an Amazon S3 bucket to store your templates, and a CodeStar Connections connection to pull and deploy your application code.
@@ -74,7 +62,7 @@ aws iam attach-role-policy \
 Then, allow Proton to use that role to provision resources for your services' continuous delivery pipelines:
 
 ```
-aws proton-preview update-account-settings \
+aws proton update-account-settings \
   --region us-east-2 \
   --pipeline-service-role-arn "arn:aws:iam::${account_id}:role/ProtonServiceRole"
 ```
@@ -92,7 +80,7 @@ Register the sample environment template, which contains an ECS Cluster and a VP
 First, create an environment template, which will contain all of the environment template's versions.
 
 ```
-aws proton-preview \
+aws proton \
   --region us-east-2 \
   create-environment-template \
   --name "aws-proton-fargate-microservices" \
@@ -109,7 +97,7 @@ aws s3 cp env-template.tar.gz s3://proton-cli-templates-${account_id}/env-templa
 
 rm env-template.tar.gz
 
-aws proton-preview \
+aws proton \
   --region us-east-2 \
   create-environment-template-version \
   --template-name "aws-proton-fargate-microservices" \
@@ -120,7 +108,7 @@ aws proton-preview \
 Wait for the environment template version to be successfully registered:
 
 ```
-aws proton-preview wait environment-template-registration-complete \
+aws proton wait environment-template-registration-complete \
   --region us-east-2 \
   --template-name "aws-proton-fargate-microservices" \
   --major-version "1" \
@@ -130,7 +118,7 @@ aws proton-preview wait environment-template-registration-complete \
 You can now publish the environment template version, making it available for users in your AWS account to create Proton environments.
 
 ```
-aws proton-preview \
+aws proton \
   --region us-east-2 \
   update-environment-template-version \
   --template-name "aws-proton-fargate-microservices" \
@@ -146,7 +134,7 @@ Register the sample services templates, which contains all the resources require
 ### First, create the Public service template.
 
 ```
-aws proton-preview \
+aws proton \
   --region us-east-2 \
   create-service-template \
   --name "lb-public-fargate-svc" \
@@ -163,7 +151,7 @@ aws s3 cp svc-private-template.tar.gz s3://proton-cli-templates-${account_id}/sv
 
 rm svc-private-template.tar.gz
 
-aws proton-preview \
+aws proton \
   --region us-east-2 \
   create-service-template-version \
   --template-name "lb-public-fargate-svc" \
@@ -175,7 +163,7 @@ aws proton-preview \
 Wait for the service template version to be successfully registered:
 
 ```
-aws proton-preview \
+aws proton \
   --region us-east-2 \
   wait service-template-registration-complete \
   --template-name "lb-public-fargate-svc" \
@@ -186,7 +174,7 @@ aws proton-preview \
 You can now publish the Public service template version, making it available for users in your AWS account to create Proton services.
 
 ```
-aws proton-preview \
+aws proton \
   --region us-east-2 \
   update-service-template-version \
   --template-name "lb-public-fargate-svc" \
@@ -198,7 +186,7 @@ aws proton-preview \
 ### Second, create the Private service template.
 
 ```
-aws proton-preview \
+aws proton \
   --region us-east-2 \
   create-service-template \
   --name "private-fargate-svc" \
@@ -215,7 +203,7 @@ aws s3 cp svc-private-template.tar.gz s3://proton-cli-templates-${account_id}/sv
 
 rm svc-private-template.tar.gz
 
-aws proton-preview \
+aws proton \
   --region us-east-2 \
   create-service-template-version \
   --template-name "private-fargate-svc" \
@@ -227,7 +215,7 @@ aws proton-preview \
 Wait for the service template version to be successfully registered:
 
 ```
-aws proton-preview \
+aws proton \
   --region us-east-2 \
   wait service-template-registration-complete \
   --template-name "private-fargate-svc" \
@@ -238,7 +226,7 @@ aws proton-preview \
 You can now publish the Public service template version, making it available for users in your AWS account to create Proton services.
 
 ```
-aws proton-preview \
+aws proton \
   --region us-east-2 \
   update-service-template-version \
   --template-name "private-fargate-svc" \
@@ -254,7 +242,7 @@ With the registered and published environment and service templates, you can now
 First, deploy a Proton environment. This command reads your environment spec at `specs/env-spec.yaml`, merges it with the environment template created above, and deploys the resources in a CloudFormation stack in your AWS account using the Proton service role.
 
 ```
-aws proton-preview create-environment \
+aws proton create-environment \
   --region us-east-2 \
   --name "Beta" \
   --template-name aws-proton-fargate-microservices \
@@ -266,7 +254,7 @@ aws proton-preview create-environment \
 Wait for the environment to successfully deploy.
 
 ```
-aws proton-preview wait environment-deployment-complete \
+aws proton wait environment-deployment-complete \
   --region us-east-2 \
   --name "Beta"
 ```
@@ -276,7 +264,7 @@ Then, create a Public Proton service and deploy it into your Proton environment.
 Fill in your CodeStar Connections connection ID and your source code repository details in this command.
 
 ```
-aws proton-preview create-service \
+aws proton create-service \
   --region us-east-2 \
   --name "front-end" \
   --repository-connection-arn arn:aws:codestar-connections:us-east-2:${account_id}:connection/<your-codestar-connection-id> \
@@ -290,7 +278,7 @@ aws proton-preview create-service \
 Wait for the service to successfully deploy.
 
 ```
-aws proton-preview wait service-creation-complete \
+aws proton wait service-creation-complete \
   --region us-east-2 \
   --name "front-end"
 ```
@@ -300,7 +288,7 @@ And finally, create a Private Proton service and deploy it into your Proton envi
 Fill in your CodeStar Connections connection ID and your source code repository details in this command.
 
 ```
-aws proton-preview create-service \
+aws proton create-service \
   --region us-east-2 \
   --name "back-end" \
   --repository-connection-arn arn:aws:codestar-connections:us-east-2:${account_id}:connection/<your-codestar-connection-id> \
@@ -314,7 +302,7 @@ aws proton-preview create-service \
 Wait for the service to successfully deploy.
 
 ```
-aws proton-preview wait service-creation-complete \
+aws proton wait service-creation-complete \
   --region us-east-2 \
   --name "back-end"
 ```

--- a/public-private-fargate-microservices/service/loadbalanced-public-svc/pipeline_infrastructure/cloudformation.yaml
+++ b/public-private-fargate-microservices/service/loadbalanced-public-svc/pipeline_infrastructure/cloudformation.yaml
@@ -36,10 +36,6 @@ Resources:
                         "docker": 18
                       },
                       "commands": [
-                        "aws s3 cp s3://aws-proton-preview-public-files/model/proton-2020-07-20.normal.json .",
-                        "aws s3 cp s3://aws-proton-preview-public-files/model/waiters2.json .",
-                        "aws configure add-model --service-model file://proton-2020-07-20.normal.json --service-name proton-preview",
-                        "mv waiters2.json ~/.aws/models/proton-preview/2020-07-20/waiters-2.json",
                         "echo 'f6bd1536a743ab170b35c94ed4c7c4479763356bd543af5d391122f4af852460  yq_linux_amd64' > yq_linux_amd64.sha",
                         "wget https://github.com/mikefarah/yq/releases/download/3.4.0/yq_linux_amd64",
                         "sha256sum -c yq_linux_amd64.sha",
@@ -69,7 +65,7 @@ Resources:
                     },
                     "post_build": {
                       "commands": [
-                        "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION get-service --name $service_name | jq -r .service.spec > service.yaml",
+                        "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION get-service --name $service_name | jq -r .service.spec > service.yaml",
                         "yq w service.yaml 'instances[*].spec.image' \"$IMAGE_ID\" > rendered_service.yaml"
                       ]
                     }
@@ -112,18 +108,10 @@ Resources:
           {
             "version": "0.2",
             "phases": {
-              "install": {
-                "commands": [
-                  "aws s3 cp s3://aws-proton-preview-public-files/model/proton-2020-07-20.normal.json .",
-                  "aws s3 cp s3://aws-proton-preview-public-files/model/waiters2.json .",
-                  "aws configure add-model --service-model file://proton-2020-07-20.normal.json --service-name proton-preview",
-                  "mv waiters2.json ~/.aws/models/proton-preview/2020-07-20/waiters-2.json"
-                ]
-              },
               "build": {
                 "commands": [
-                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --deployment-type CURRENT_VERSION --name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
-                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --name $service_instance_name --service-name $service_name"
+                  "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --deployment-type CURRENT_VERSION --name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
+                  "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --name $service_instance_name --service-name $service_name"
                 ]
               }
             }
@@ -215,10 +203,6 @@ Resources:
               - proton:GetService
             Effect: Allow
             Resource: "*"
-          - Action: s3:GetObject
-            Effect: Allow
-            Resource:
-              - "arn:aws:s3:::aws-proton-preview-public-files/*"
           - Action:
               - s3:GetObject*
               - s3:GetBucket*
@@ -324,10 +308,6 @@ Resources:
               - proton:GetServiceInstance
             Effect: Allow
             Resource: "*"
-          - Action: s3:GetObject
-            Effect: Allow
-            Resource:
-              - "arn:aws:s3:::aws-proton-preview-public-files/*"
           - Action:
               - s3:GetObject*
               - s3:GetBucket*

--- a/public-private-fargate-microservices/service/private-fargate-svc/pipeline_infrastructure/cloudformation.yaml
+++ b/public-private-fargate-microservices/service/private-fargate-svc/pipeline_infrastructure/cloudformation.yaml
@@ -36,10 +36,6 @@ Resources:
                         "docker": 18
                       },
                       "commands": [
-                        "aws s3 cp s3://aws-proton-preview-public-files/model/proton-2020-07-20.normal.json .",
-                        "aws s3 cp s3://aws-proton-preview-public-files/model/waiters2.json .",
-                        "aws configure add-model --service-model file://proton-2020-07-20.normal.json --service-name proton-preview",
-                        "mv waiters2.json ~/.aws/models/proton-preview/2020-07-20/waiters-2.json",
                         "echo 'f6bd1536a743ab170b35c94ed4c7c4479763356bd543af5d391122f4af852460  yq_linux_amd64' > yq_linux_amd64.sha",
                         "wget https://github.com/mikefarah/yq/releases/download/3.4.0/yq_linux_amd64",
                         "sha256sum -c yq_linux_amd64.sha",
@@ -69,7 +65,7 @@ Resources:
                     },
                     "post_build": {
                       "commands": [
-                        "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION get-service --name $service_name | jq -r .service.spec > service.yaml",
+                        "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION get-service --name $service_name | jq -r .service.spec > service.yaml",
                         "yq w service.yaml 'instances[*].spec.image' \"$IMAGE_ID\" > rendered_service.yaml"
                       ]
                     }
@@ -112,18 +108,10 @@ Resources:
           {
             "version": "0.2",
             "phases": {
-              "install": {
-                "commands": [
-                  "aws s3 cp s3://aws-proton-preview-public-files/model/proton-2020-07-20.normal.json .",
-                  "aws s3 cp s3://aws-proton-preview-public-files/model/waiters2.json .",
-                  "aws configure add-model --service-model file://proton-2020-07-20.normal.json --service-name proton-preview",
-                  "mv waiters2.json ~/.aws/models/proton-preview/2020-07-20/waiters-2.json"
-                ]
-              },
               "build": {
                 "commands": [
-                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --deployment-type CURRENT_VERSION --name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
-                  "aws proton-preview --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --name $service_instance_name --service-name $service_name"
+                  "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --deployment-type CURRENT_VERSION --name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
+                  "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --name $service_instance_name --service-name $service_name"
                 ]
               }
             }
@@ -215,10 +203,6 @@ Resources:
               - proton:GetService
             Effect: Allow
             Resource: "*"
-          - Action: s3:GetObject
-            Effect: Allow
-            Resource:
-              - "arn:aws:s3:::aws-proton-preview-public-files/*"
           - Action:
               - s3:GetObject*
               - s3:GetBucket*
@@ -324,10 +308,6 @@ Resources:
               - proton:GetServiceInstance
             Effect: Allow
             Resource: "*"
-          - Action: s3:GetObject
-            Effect: Allow
-            Resource:
-              - "arn:aws:s3:::aws-proton-preview-public-files/*"
           - Action:
               - s3:GetObject*
               - s3:GetBucket*


### PR DESCRIPTION
Proton is going GA any day now, and we will be built natively into the console.  This PR updates the templates and instructions to use Proton in the native CLI.