### PR TITLE
Fix typo in subnet_two_cidr's description

### DIFF
--- a/loadbalanced-fargate-svc/environment/schema/schema.yaml
+++ b/loadbalanced-fargate-svc/environment/schema/schema.yaml
@@ -19,6 +19,6 @@ schema:
           pattern: ([0-9]{1,3}\.){3}[0-9]{1,3}($|/(16|24))
         subnet_two_cidr:
           type: string
-          description: "The CIDR range for subnet one"
+          description: "The CIDR range for subnet two"
           default: 10.0.1.0/24
           pattern: ([0-9]{1,3}\.){3}[0-9]{1,3}($|/(16|24))


### PR DESCRIPTION
*Description of changes:*
Fix typo in the description of _subnet_two_cidr_ in _loadbalanced-fargate-svc/environment/schema/schema.yaml_:
> The CIDR range for subnet ~~one~~ two

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
