### PR TITLE
Remove bad argument from CLI command

### DIFF
--- a/loadbalanced-fargate-svc/README.md
+++ b/loadbalanced-fargate-svc/README.md
@@ -138,7 +138,6 @@ aws proton create-service-template-version \
   --region us-west-2 \
   --template-name "lb-fargate-service" \
   --description "Version 1" \
-  --major-version "1" \
   --source s3="{bucket=proton-cli-templates-${account_id},key=svc-template.tar.gz}" \
   --compatible-environment-templates '[{"templateName":"public-vpc","majorVersion":"1"}]'
 ```


### PR DESCRIPTION
When creating the first major version of a service template the `--major-version` argument should be omitted, otherwise Proton will return an error.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
