### PR TITLE
upgrading aws cli version to latest 1.9.x version

### DIFF
--- a/lambda-multi-svc/service-crud/pipeline_infrastructure/cloudformation.yaml
+++ b/lambda-multi-svc/service-crud/pipeline_infrastructure/cloudformation.yaml
@@ -45,6 +45,7 @@ Resources:
                             "dotnetcore3.1": {"dotnet": "3.1"}
                           }[service_instances[0].outputs.LambdaRuntime] | tojson | safe }},
                       "commands": [
+                        "pip3 install --upgrade --user awscli",
                         "echo 'f6bd1536a743ab170b35c94ed4c7c4479763356bd543af5d391122f4af852460  yq_linux_amd64' > yq_linux_amd64.sha",
                         "wget https://github.com/mikefarah/yq/releases/download/3.4.0/yq_linux_amd64",
                         "sha256sum -c yq_linux_amd64.sha",
@@ -112,6 +113,7 @@ Resources:
             "phases": {
               "build": {
                 "commands": [
+                  "pip3 install --upgrade --user awscli",
                   "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --deployment-type CURRENT_VERSION --name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
                   "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --name $service_instance_name --service-name $service_name"
                 ]

--- a/lambda-multi-svc/service-data-processing/pipeline_infrastructure/cloudformation.yaml
+++ b/lambda-multi-svc/service-data-processing/pipeline_infrastructure/cloudformation.yaml
@@ -45,6 +45,7 @@ Resources:
                             "dotnetcore3.1": {"dotnet": "3.1"}
                           }[service_instances[0].outputs.LambdaRuntime] | tojson | safe }},
                       "commands": [
+                        "pip3 install --upgrade --user awscli",
                         "echo 'f6bd1536a743ab170b35c94ed4c7c4479763356bd543af5d391122f4af852460  yq_linux_amd64' > yq_linux_amd64.sha",
                         "wget https://github.com/mikefarah/yq/releases/download/3.4.0/yq_linux_amd64",
                         "sha256sum -c yq_linux_amd64.sha",
@@ -112,6 +113,7 @@ Resources:
             "phases": {
               "build": {
                 "commands": [
+                  "pip3 install --upgrade --user awscli",
                   "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --version-update-type UPDATE_SPEC --name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
                   "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --name $service_instance_name --service-name $service_name"
                 ]

--- a/loadbalanced-fargate-svc/service/pipeline_infrastructure/cloudformation.yaml
+++ b/loadbalanced-fargate-svc/service/pipeline_infrastructure/cloudformation.yaml
@@ -36,6 +36,7 @@ Resources:
                         "docker": 18
                       },
                       "commands": [
+                        "pip3 install --upgrade --user awscli",
                         "echo 'f6bd1536a743ab170b35c94ed4c7c4479763356bd543af5d391122f4af852460  yq_linux_amd64' > yq_linux_amd64.sha",
                         "wget https://github.com/mikefarah/yq/releases/download/3.4.0/yq_linux_amd64",
                         "sha256sum -c yq_linux_amd64.sha",
@@ -110,6 +111,7 @@ Resources:
             "phases": {
               "build": {
                 "commands": [
+                  "pip3 install --upgrade --user awscli",
                   "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --deployment-type CURRENT_VERSION --name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
                   "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --name $service_instance_name --service-name $service_name"
                 ]

--- a/public-private-fargate-microservices/service/loadbalanced-public-svc/pipeline_infrastructure/cloudformation.yaml
+++ b/public-private-fargate-microservices/service/loadbalanced-public-svc/pipeline_infrastructure/cloudformation.yaml
@@ -36,6 +36,7 @@ Resources:
                         "docker": 18
                       },
                       "commands": [
+                        "pip3 install --upgrade --user awscli",
                         "echo 'f6bd1536a743ab170b35c94ed4c7c4479763356bd543af5d391122f4af852460  yq_linux_amd64' > yq_linux_amd64.sha",
                         "wget https://github.com/mikefarah/yq/releases/download/3.4.0/yq_linux_amd64",
                         "sha256sum -c yq_linux_amd64.sha",
@@ -110,6 +111,7 @@ Resources:
             "phases": {
               "build": {
                 "commands": [
+                  "pip3 install --upgrade --user awscli",
                   "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --deployment-type CURRENT_VERSION --name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
                   "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --name $service_instance_name --service-name $service_name"
                 ]

--- a/public-private-fargate-microservices/service/private-fargate-svc/pipeline_infrastructure/cloudformation.yaml
+++ b/public-private-fargate-microservices/service/private-fargate-svc/pipeline_infrastructure/cloudformation.yaml
@@ -36,6 +36,7 @@ Resources:
                         "docker": 18
                       },
                       "commands": [
+                        "pip3 install --upgrade --user awscli",
                         "echo 'f6bd1536a743ab170b35c94ed4c7c4479763356bd543af5d391122f4af852460  yq_linux_amd64' > yq_linux_amd64.sha",
                         "wget https://github.com/mikefarah/yq/releases/download/3.4.0/yq_linux_amd64",
                         "sha256sum -c yq_linux_amd64.sha",
@@ -110,6 +111,7 @@ Resources:
             "phases": {
               "build": {
                 "commands": [
+                  "pip3 install --upgrade --user awscli",
                   "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION update-service-instance --deployment-type CURRENT_VERSION --name $service_instance_name --service-name $service_name --spec file://rendered_service.yaml",
                   "aws proton --endpoint-url https://proton.$AWS_DEFAULT_REGION.amazonaws.com --region $AWS_DEFAULT_REGION wait service-instance-update-complete --name $service_instance_name --service-name $service_name"
                 ]


### PR DESCRIPTION
*https://t.corp.amazon.com/D24538641*

*Adding commands to upgrade aws cli version to latest 1.9.x version before running aws proton commands*

Instructions : https://docs.aws.amazon.com/cli/latest/userguide/install-linux-al2017.html

```
[Container] 2021/06/24 14:55:27 Entering phase BUILD
[Container] 2021/06/24 14:55:27 Running command pip3 install --upgrade --user awscli
Collecting awscli
  Downloading awscli-1.19.99-py2.py3-none-any.whl (3.6 MB)
Requirement already satisfied, skipping upgrade: docutils<0.16,>=0.10 in /root/.pyenv/versions/3.8.8/lib/python3.8/site-packages (from awscli) (0.15.2)
.
.
.
Installing collected packages: botocore, awscli
Successfully installed awscli-1.19.99 botocore-1.20.99
--


</span></span><span><span>Requirement already 
satisfied, skipping upgrade: colorama&lt;0.4.4,&gt;=0.2.5 in 
/root/.pyenv/versions/3.8.8/lib/python3.8/site-packages (from awscli) 
(0.4.3)</span></span>
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
