### PR TITLE
fix(schema.yaml): fix Nginx CVE-2021-23017

### DIFF
--- a/loadbalanced-fargate-svc/service/schema/schema.yaml
+++ b/loadbalanced-fargate-svc/service/schema/schema.yaml
@@ -28,7 +28,7 @@ schema:
         image:
           type: string
           description: "The name/url of the container image"
-          default: "public.ecr.aws/z9d2n7e1/nginx:1.19.5"
+          default: "public.ecr.aws/z9d2n7e1/nginx:1.21.0"
           minLength: 1
           maxLength: 200
 

--- a/public-private-fargate-microservices/service/loadbalanced-public-svc/schema/schema.yaml
+++ b/public-private-fargate-microservices/service/loadbalanced-public-svc/schema/schema.yaml
@@ -28,7 +28,7 @@ schema:
         image:
           type: string
           description: "The name/url of the container image"
-          default: "public.ecr.aws/z9d2n7e1/nginx:1.19.5"
+          default: "public.ecr.aws/z9d2n7e1/nginx:1.21.0"
           minLength: 1
           maxLength: 200
         service_discovery_name:

--- a/public-private-fargate-microservices/service/private-fargate-svc/schema/schema.yaml
+++ b/public-private-fargate-microservices/service/private-fargate-svc/schema/schema.yaml
@@ -28,7 +28,7 @@ schema:
         image:
           type: string
           description: "The name/url of the container image"
-          default: "public.ecr.aws/z9d2n7e1/nginx:1.19.5"
+          default: "public.ecr.aws/z9d2n7e1/nginx:1.21.0"
           minLength: 1
           maxLength: 200
         service_discovery_name:


### PR DESCRIPTION
Change Nginx from 1.19.5 to 1.21.0 to fix CVE-2021-23017
https://nvd.nist.gov/vuln/detail/CVE-2021-23017
https://nginx.org/en/security_advisories.html

CVE-2021-23017