### PR TITLE
docs(CONTRIBUTING.md): fix minor spelling typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ opensource-codeofconduct@amazon.com with any additional questions or comments.
 
 
 ## Security issue notifications
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
+If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public GitHub issue.
 
 
 ## Licensing


### PR DESCRIPTION
Fix minor spelling typo:
• Capitalize "G" and "H" — Respell "github" as "GitHub"
• This creates consistency with the remainder of this CONTRIBUTING.md document
• This is in alignment with the formal spelling of "GitHub" by GitHub, Inc.