### PR TITLE
Config truncate leeway to 0 to keep the taget group name within limit.

### DIFF
--- a/loadbalanced-fargate-svc/service/instance_infrastructure/cloudformation.yaml
+++ b/loadbalanced-fargate-svc/service/instance_infrastructure/cloudformation.yaml
@@ -97,7 +97,7 @@ Resources:
       # reached by using either {{service.name}}, {{service_instance.name}}
       # or a combination of both as we're doing here, so we truncate the name to 29 characters
       # plus an ellipsis different from '...' or '---' to avoid running into errors.
-      Name: '{{(service.name~"--"~service_instance.name)|truncate(29, true, 'zzz')}}'
+      Name: '{{(service.name~"--"~service_instance.name)|truncate(29, true, 'zzz', 0)}}'
       Port: '{{service_instance.inputs.port}}'
       Protocol: HTTP
       UnhealthyThresholdCount: 2

--- a/public-private-fargate-microservices/service/loadbalanced-public-svc/instance_infrastructure/cloudformation.yaml
+++ b/public-private-fargate-microservices/service/loadbalanced-public-svc/instance_infrastructure/cloudformation.yaml
@@ -123,7 +123,7 @@ Resources:
       # reached by using either {{service.name}}, {{service_instance.name}}
       # or a combination of both as we're doing here, so we truncate the name to 29 characters
       # plus an ellipsis different from '...' or '---' to avoid running into errors.
-      Name: '{{(service.name~"--"~service_instance.name)|truncate(29, true, 'zzz')}}'
+      Name: '{{(service.name~"--"~service_instance.name)|truncate(29, true, 'zzz', 0)}}'
       Port: '{{service_instance.inputs.port}}'
       Protocol: HTTP
       UnhealthyThresholdCount: 2


### PR DESCRIPTION
*Issue #, if available:

From [Jinja doc](https://jinja.palletsprojects.com/en/3.0.x/templates/#jinja-filters.truncate): The default leeway on newer Jinja versions is 5 and was 0 before but can be reconfigured globally.

We need to set the leeway to 0 to prevent name from exceeding the limit.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
