### PR TITLE
fixed samples to no longer need parameter for environment id

### DIFF
--- a/lambda-multi-svc/README.md
+++ b/lambda-multi-svc/README.md
@@ -290,9 +290,6 @@ With the registered and published service template and deployed environment, you
 This command reads your service spec at `specs/svc-spec.yaml`, merges it with the service template created above, and deploys the resources in CloudFormation stacks in the AWS account of the environment.  
 The service will provision a Lambda-based CRUD API endpoint and a CodePipeline pipeline to deploy your application code.
 
-If you are deploying the service in a cross account environment, you need to enter the environment AWS account id(s) in `specs/svc-spec.yaml` `pipeline: environment_account_ids`, for example "111222333444,222333444555".
-This gives environment accounts permission to get the function artifacts from S3 Bucket in the management account.
-
 Fill in your CodeStar Connections connection ID and your source code repository details in this command.
 
 ```bash

--- a/lambda-multi-svc/service-crud/pipeline_infrastructure/cloudformation.yaml
+++ b/lambda-multi-svc/service-crud/pipeline_infrastructure/cloudformation.yaml
@@ -9,7 +9,6 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: 'AES256'
-  {% if pipeline.inputs.environment_account_ids %}
   # This policy allows environment accounts to get the build artifacts from FunctionBucket in the management account
   FunctionBucketPolicy:
     Type: AWS::S3::BucketPolicy
@@ -28,11 +27,9 @@ Resources:
                 - /*
             Principal:
               AWS:
-                {% set environment_account_ids = pipeline.inputs.environment_account_ids.split(',') %}
-                {% for environment_account_id in environment_account_ids %}
-                - "arn:aws:iam::{{environment_account_id}}:root"
+                {% for service_instance in service_instances %}
+                - "arn:aws:iam::{{service_instance.environment.account_id}}:root"
                 {% endfor %}
-  {% endif %}
   BuildProject:
     Type: AWS::CodeBuild::Project
     Properties:

--- a/lambda-multi-svc/service-crud/schema/schema.yaml
+++ b/lambda-multi-svc/service-crud/schema/schema.yaml
@@ -60,10 +60,3 @@ schema:
           default: "make publish"
           minLength: 1
           maxLength: 200
-        environment_account_ids:
-          type: string
-          pattern: '^$|^\d{12}(,\d{12})*$'
-          description: "The environment account ids for service instances using cross account environment, separated by ,"
-          default: ""
-          maxLength: 200
-

--- a/lambda-multi-svc/service-data-processing/pipeline_infrastructure/cloudformation.yaml
+++ b/lambda-multi-svc/service-data-processing/pipeline_infrastructure/cloudformation.yaml
@@ -9,7 +9,6 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: 'AES256'
-  {% if pipeline.inputs.environment_account_ids %}
   # This policy allows environment accounts to get the build artifacts from FunctionBucket in the management account
   FunctionBucketPolicy:
     Type: AWS::S3::BucketPolicy
@@ -28,11 +27,9 @@ Resources:
                 - /*
             Principal:
               AWS:
-                {% set environment_account_ids = pipeline.inputs.environment_account_ids.split(',') %}
-                {% for environment_account_id in environment_account_ids %}
-                - "arn:aws:iam::{{environment_account_id}}:root"
+                {% for service_instance in service_instances %}
+                - "arn:aws:iam::{{service_instance.environment.account_id}}:root"
                 {% endfor %}
-  {% endif %}
   BuildProject:
     Type: AWS::CodeBuild::Project
     Properties:

--- a/lambda-multi-svc/service-data-processing/schema/schema.yaml
+++ b/lambda-multi-svc/service-data-processing/schema/schema.yaml
@@ -66,10 +66,3 @@ schema:
           default: "make publish"
           minLength: 1
           maxLength: 200
-        environment_account_ids:
-          type: string
-          pattern: '^$|^\d{12}(,\d{12})*$'
-          description: "The environment account ids for service instances using cross account environment, separated by ,"
-          default: ""
-          maxLength: 200
-

--- a/lambda-multi-svc/specs/svc-spec.yaml
+++ b/lambda-multi-svc/specs/svc-spec.yaml
@@ -3,7 +3,6 @@ proton: ServiceSpec
 pipeline:
   unit_test_command: make test
   packaging_commands: make publish
-  environment_account_ids: ""
 
 instances:
   - name: "front-end"

--- a/loadbalanced-fargate-svc/README.md
+++ b/loadbalanced-fargate-svc/README.md
@@ -256,9 +256,6 @@ With the registered and published service template and deployed environment, you
 This command reads your service spec at `specs/svc-spec.yaml`, merges it with the service template created above, and deploys the resources in CloudFormation stacks in the AWS account of the environment.  
 The service will provision a Lambda-based CRUD API endpoint and a CodePipeline pipeline to deploy your application code.
 
-If you are deploying the service in a cross account environment, you need to enter the environment AWS account id(s) in `specs/svc-spec.yaml` `pipeline: environment_account_ids`, for example "111222333444,222333444555".
-This gives environment accounts permissions to get the images from ECR repository in the management account.
-
 Fill in your CodeStar Connections connection ID and your source code repository details in this command.
 
 ```bash

--- a/loadbalanced-fargate-svc/service/pipeline_infrastructure/cloudformation.yaml
+++ b/loadbalanced-fargate-svc/service/pipeline_infrastructure/cloudformation.yaml
@@ -2,7 +2,6 @@ Resources:
   ECRRepo:
     Type: AWS::ECR::Repository
     DeletionPolicy: Retain
-    {% if pipeline.inputs.environment_account_ids %}
     Properties:
       # This policy allows environment accounts to get the image from ECRRepo in the management account
       RepositoryPolicyText:
@@ -12,16 +11,14 @@ Resources:
             Effect: Allow
             Principal:
               AWS:
-                {% set environment_account_ids = pipeline.inputs.environment_account_ids.split(',') %}
-                {% for environment_account_id in environment_account_ids %}
-                - "arn:aws:iam::{{environment_account_id}}:root"
+                {% for service_instance in service_instances %}
+                - "arn:aws:iam::{{service_instance.environment.account_id}}:root"
                 {% endfor %}
             Action:
               - ecr:GetAuthorizationToken
               - ecr:BatchCheckLayerAvailability
               - ecr:GetDownloadUrlForLayer
               - ecr:BatchGetImage
-    {% endif %}
   BuildProject:
     Type: AWS::CodeBuild::Project
     Properties:

--- a/loadbalanced-fargate-svc/service/schema/schema.yaml
+++ b/loadbalanced-fargate-svc/service/schema/schema.yaml
@@ -48,9 +48,3 @@ schema:
           default: "echo 'add your unit test command here'"
           minLength: 1
           maxLength: 200
-        environment_account_ids:
-          type: string
-          pattern: '^$|^\d{12}(,\d{12})*$'
-          description: "The environment account ids for service instances using cross account environment, separated by ,"
-          default: ""
-          maxLength: 200

--- a/loadbalanced-fargate-svc/specs/svc-spec.yaml
+++ b/loadbalanced-fargate-svc/specs/svc-spec.yaml
@@ -2,7 +2,6 @@ proton: ServiceSpec
 
 pipeline:
   unit_test_command: "ls"
-  environment_account_ids: ""
 
 instances:
   - name: "frontend-dev"

--- a/public-private-fargate-microservices/README.md
+++ b/public-private-fargate-microservices/README.md
@@ -302,9 +302,6 @@ With the registered and published service template and deployed environment, you
 This command reads your service spec at `specs/svc-public--spec.yaml`, merges it with the service template created above, and deploys the resources in CloudFormation stacks in the AWS account of the environment.  
 The service will provision a Lambda-based CRUD API endpoint and a CodePipeline pipeline to deploy your application code.
 
-If you are deploying the service in a cross account environment, you need to enter the environment AWS account id(s) in `specs/svc-public-spec.yaml` `pipeline: environment_account_ids`, for example "111222333444,222333444555".
-This gives environment accounts permissions to get the images from ECR repository in the management account.
-
 Fill in your CodeStar Connections connection ID and your source code repository details in this command.
 
 ```
@@ -328,7 +325,6 @@ aws proton get-service --name front-end
 
 And finally, create a Private Proton service and deploy it into your Proton environment.  This command reads your service spec at `specs/svc-private-spec.yaml`, merges it with the service template created above, and deploys the resources in CloudFormation stacks in your AWS account using the Proton service role. The service will provision a private ECS service running on Fargate and a CodePipeline pipeline to deploy your application code.
 
-If you are deploying the service in a cross account environment, you need to enter the environment AWS account id(s) in `specs/svc-private-spec.yaml` `pipeline: environment_account_ids`, for example "111222333444,222333444555".
 
 Fill in your CodeStar Connections connection ID and your source code repository details in this command.
 

--- a/public-private-fargate-microservices/service/loadbalanced-public-svc/pipeline_infrastructure/cloudformation.yaml
+++ b/public-private-fargate-microservices/service/loadbalanced-public-svc/pipeline_infrastructure/cloudformation.yaml
@@ -2,7 +2,6 @@ Resources:
   ECRRepo:
     Type: AWS::ECR::Repository
     DeletionPolicy: Retain
-    {% if pipeline.inputs.environment_account_ids %}
     Properties:
       # This policy allows environment accounts to get the image from ECRRepo in the management account
       RepositoryPolicyText:
@@ -12,16 +11,14 @@ Resources:
             Effect: Allow
             Principal:
               AWS:
-                {% set environment_account_ids = pipeline.inputs.environment_account_ids.split(',') %}
-                {% for environment_account_id in environment_account_ids %}
-                - "arn:aws:iam::{{environment_account_id}}:root"
+                {% for service_instance in service_instances %}
+                - "arn:aws:iam::{{service_instance.environment.account_id}}:root"
                 {% endfor %}
             Action:
               - ecr:GetAuthorizationToken
               - ecr:BatchCheckLayerAvailability
               - ecr:GetDownloadUrlForLayer
               - ecr:BatchGetImage
-    {% endif %}
   BuildProject:
     Type: AWS::CodeBuild::Project
     Properties:

--- a/public-private-fargate-microservices/service/loadbalanced-public-svc/schema/schema.yaml
+++ b/public-private-fargate-microservices/service/loadbalanced-public-svc/schema/schema.yaml
@@ -55,9 +55,3 @@ schema:
           default: "echo 'add your unit test command here'"
           minLength: 1
           maxLength: 200
-        environment_account_ids:
-          type: string
-          pattern: '^$|^\d{12}(,\d{12})*$'
-          description: "The environment account ids for service instances using cross account environment, separated by ,"
-          default: ""
-          maxLength: 200

--- a/public-private-fargate-microservices/service/private-fargate-svc/pipeline_infrastructure/cloudformation.yaml
+++ b/public-private-fargate-microservices/service/private-fargate-svc/pipeline_infrastructure/cloudformation.yaml
@@ -2,7 +2,6 @@ Resources:
   ECRRepo:
     Type: AWS::ECR::Repository
     DeletionPolicy: Retain
-    {% if pipeline.inputs.environment_account_ids %}
     Properties:
       # This policy allows environment accounts to get the image from ECRRepo in the management account
       RepositoryPolicyText:
@@ -12,16 +11,14 @@ Resources:
             Effect: Allow
             Principal:
               AWS:
-                {% set environment_account_ids = pipeline.inputs.environment_account_ids.split(',') %}
-                {% for environment_account_id in environment_account_ids %}
-                - "arn:aws:iam::{{environment_account_id}}:root"
+                {% for service_instance in service_instances %}
+                - "arn:aws:iam::{{service_instance.environment.account_id}}:root"
                 {% endfor %}
             Action:
               - ecr:GetAuthorizationToken
               - ecr:BatchCheckLayerAvailability
               - ecr:GetDownloadUrlForLayer
               - ecr:BatchGetImage
-    {% endif %}
   BuildProject:
     Type: AWS::CodeBuild::Project
     Properties:

--- a/public-private-fargate-microservices/service/private-fargate-svc/schema/schema.yaml
+++ b/public-private-fargate-microservices/service/private-fargate-svc/schema/schema.yaml
@@ -55,9 +55,3 @@ schema:
           default: "echo 'add your unit test command here'"
           minLength: 1
           maxLength: 200
-        environment_account_ids:
-          type: string
-          pattern: '^$|^\d{12}(,\d{12})*$'
-          description: "The environment account ids for service instances using cross account environment, separated by ,"
-          default: ""
-          maxLength: 200

--- a/public-private-fargate-microservices/specs/svc-private-spec.yaml
+++ b/public-private-fargate-microservices/specs/svc-private-spec.yaml
@@ -2,7 +2,6 @@ proton: ServiceSpec
 
 pipeline:
   unit_test_command: "ls"
-  environment_account_ids: ""
 
 instances:
   - name: "backend-dev"

--- a/public-private-fargate-microservices/specs/svc-public-spec.yaml
+++ b/public-private-fargate-microservices/specs/svc-public-spec.yaml
@@ -2,7 +2,6 @@ proton: ServiceSpec
 
 pipeline:
   unit_test_command: "ls"
-  environment_account_ids: ""
 
 instances:
   - name: "frontend-dev"


### PR DESCRIPTION
*Description of changes:*
`env_account_ids` had to be passed in as a parameter, this change fixes that to use newly added `account_id` parameter in service_instance