### PR TITLE
Tweaked Deploy name in the pipeline + proper formatting for readability

### DIFF
--- a/loadbalanced-fargate-svc/service/pipeline_infrastructure/cloudformation.yaml
+++ b/loadbalanced-fargate-svc/service/pipeline_infrastructure/cloudformation.yaml
@@ -594,7 +594,8 @@ Resources:
                   - PipelineBuildCodePipelineActionRole
                   - Arn
               RunOrder: 1
-          Name: Build {%- for service_instance in service_instances %}
+          Name: Build 
+{%- for service_instance in service_instances %}
         - Actions:
             - ActionTypeId:
                 Category: Build
@@ -612,7 +613,7 @@ Resources:
                   - PipelineDeployCodePipelineActionRole
                   - Arn
               RunOrder: 1
-          Name: 'Deploy{{service_instance.name}}'
+          Name: 'Deploy-{{service_instance.name}}'
 {%- endfor %}
       ArtifactStore:
         EncryptionKey:


### PR DESCRIPTION
I have added an `-` between `Deploy` and the name of the service instance. 

Also I have formatted the text for better readability (the Jinja entry just above the tweak was misplaced and hard to resonate about when looking at the code)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
