### PR TITLE
V539724385: Pipeline does not run when add/removing service instances

### DIFF
--- a/lambda-multi-svc/lambda-env/v1/schema/schema.yaml
+++ b/lambda-multi-svc/lambda-env/v1/schema/schema.yaml
@@ -6,6 +6,8 @@ schema:
     EnvironmentInput:
       type: object
       description: "Input properties for my environment"
+      required:
+        - ttl_attribute
       properties:
         ttl_attribute:
           type: string

--- a/lambda-multi-svc/service-crud/v1/pipeline_infrastructure/cloudformation.yaml
+++ b/lambda-multi-svc/service-crud/v1/pipeline_infrastructure/cloudformation.yaml
@@ -564,6 +564,7 @@ Resources:
   Pipeline:
     Type: AWS::CodePipeline::Pipeline
     Properties:
+      RestartExecutionOnUpdate: true
       RoleArn:
         Fn::GetAtt:
           - PipelineRole

--- a/lambda-multi-svc/service-data-processing/v1/pipeline_infrastructure/cloudformation.yaml
+++ b/lambda-multi-svc/service-data-processing/v1/pipeline_infrastructure/cloudformation.yaml
@@ -564,6 +564,7 @@ Resources:
   Pipeline:
     Type: AWS::CodePipeline::Pipeline
     Properties:
+      RestartExecutionOnUpdate: true
       RoleArn:
         Fn::GetAtt:
           - PipelineRole

--- a/loadbalanced-fargate-svc/loadbalanced-fargate-svc/v1/pipeline_infrastructure/cloudformation.yaml
+++ b/loadbalanced-fargate-svc/loadbalanced-fargate-svc/v1/pipeline_infrastructure/cloudformation.yaml
@@ -555,6 +555,7 @@ Resources:
   Pipeline:
     Type: AWS::CodePipeline::Pipeline
     Properties:
+      RestartExecutionOnUpdate: true
       RoleArn:
         Fn::GetAtt:
           - PipelineRole

--- a/public-private-fargate-microservices/microservices-svc/loadbalanced-public-svc/v1/pipeline_infrastructure/cloudformation.yaml
+++ b/public-private-fargate-microservices/microservices-svc/loadbalanced-public-svc/v1/pipeline_infrastructure/cloudformation.yaml
@@ -555,6 +555,7 @@ Resources:
   Pipeline:
     Type: AWS::CodePipeline::Pipeline
     Properties:
+      RestartExecutionOnUpdate: true
       RoleArn:
         Fn::GetAtt:
           - PipelineRole

--- a/public-private-fargate-microservices/microservices-svc/private-fargate-svc/v1/pipeline_infrastructure/cloudformation.yaml
+++ b/public-private-fargate-microservices/microservices-svc/private-fargate-svc/v1/pipeline_infrastructure/cloudformation.yaml
@@ -555,6 +555,7 @@ Resources:
   Pipeline:
     Type: AWS::CodePipeline::Pipeline
     Properties:
+      RestartExecutionOnUpdate: true
       RoleArn:
         Fn::GetAtt:
           - PipelineRole


### PR DESCRIPTION
[V539724385: Pipeline does not run when add/removing service instances](https://github.com/aws-samples/aws-proton-sample-templates/commit/67863a75800c22735c739a541859071386a1d05a) 

### Description
* We needed to enable "RestartExecutionOnUpdate" in our sample's pipeline definition to rerun the CodePipeline pipeline after an update.
* Update ttl_attribute to be required (P43342158)

### Tests
* Tested locally using the updated lambda-svc template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
