### PR TITLE
exposes health check in lb-fargate-svc

### DIFF
--- a/loadbalanced-fargate-svc/loadbalanced-fargate-svc/v1/instance_infrastructure/cloudformation.yaml
+++ b/loadbalanced-fargate-svc/loadbalanced-fargate-svc/v1/instance_infrastructure/cloudformation.yaml
@@ -88,7 +88,7 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       HealthCheckIntervalSeconds: 6
-      HealthCheckPath: '{{ service_instance.inputs.health_check }}'
+      HealthCheckPath: '{{ service_instance.inputs.health_check_path }}'
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2

--- a/loadbalanced-fargate-svc/loadbalanced-fargate-svc/v1/schema/schema.yaml
+++ b/loadbalanced-fargate-svc/loadbalanced-fargate-svc/v1/schema/schema.yaml
@@ -16,7 +16,7 @@ schema:
           default: 80
           minimum: 0
           maximum: 65535
-        health_check:
+        health_check_path:
           title: Health Check Path
           description: The health check path
           type: string


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In order to be able to use a greater range of apps when demoing the sample `loadbalanced-fargate-svc` template, it would be nice to be able to change the health check.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
