### PR TITLE
Update ecs-ec2-env to python3.8

### DIFF
--- a/environment-templates/ecs-ec2-env/v1/infrastructure/cloudformation.yaml
+++ b/environment-templates/ecs-ec2-env/v1/infrastructure/cloudformation.yaml
@@ -468,7 +468,7 @@ Resources:
           CLUSTER:
             Ref: Cluster
       Handler: index.lambda_handler
-      Runtime: python3.6
+      Runtime: python3.8
       Timeout: 310
     DependsOn:
       - ECSDrainHookFunctionServiceRoleDefaultPolicy


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Avoid stack rollback due to python3.6 being used in ecs-ec2-env template. Update to 3.8 like the rest of the templates (not sure if we should just bump to 3.9 now?).

CloudFormation error message during `ECSDrainHookFunction` resource creation:
```
Resource handler returned message: "The runtime parameter of python3.6 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.9) while creating or updating functions. (Service: Lambda, Status Code: 400, Request ID: 2194cd3d-e27a-44da-8e32-5d8f050739c3)" (RequestToken: 15029625-ddd4-6ade-274e-49730665bfa4, HandlerErrorCode: InvalidRequest)
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
